### PR TITLE
✨ [feat] RadioButton 공통 컴포넌트 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 /* === Tailwind v4 테마 설정 === */
 @theme {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,32 +1,32 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 /* === Tailwind v4 테마 설정 === */
 @theme {
-  --color-black-100: hsl(0, 0, 42);
-  --color-black-200: hsl(0, 0, 32);
-  --color-black-300: hsl(0, 0, 22);
-  --color-black-400: hsl(0, 0, 12);
-  --color-black-500: hsl(0, 0, 2);
-  --color-gray-50: hsl(0, 0, 100);
-  --color-gray-100: hsl(0, 0, 87);
-  --color-gray-200: hsl(0, 0, 77);
-  --color-gray-300: hsl(0, 0, 67);
-  --color-gray-400: hsl(0, 0, 60);
-  --color-gray-500: hsl(0, 0, 50);
-  --color-blue-100: hsl(234, 19, 40);
-  --color-blue-200: hsl(234, 18, 30);
-  --color-blue-300: hsl(234, 18, 20);
-  --color-background-100: hsl(0, 0, 99);
-  --color-background-200: hsl(0, 0, 97);
-  --color-background-300: hsl(0, 0, 94);
-  --color-line-100: hsl(0, 0, 95);
-  --color-line-100: hsl(0, 0, 95);
-  --color-error: hsl(15, 100, 49);
-  --color-mint-50: hsl(171, 86, 88);
-  --color-mint-100: hsl(171, 86, 68);
-  --color-mint-200: hsl(171, 86, 58);
-  --color-mint-300: hsl(171, 86, 48);
-  --color-mint-400: hsl(171, 86, 38);
+  --color-black-100: hsl(0, 0%, 42%);
+  --color-black-200: hsl(0, 0%, 32%);
+  --color-black-300: hsl(0, 0%, 22%);
+  --color-black-400: hsl(0, 0%, 12%);
+  --color-black-500: hsl(0, 0%, 2%);
+  --color-gray-50: hsl(0, 0%, 100%);
+  --color-gray-100: hsl(0, 0%, 87%);
+  --color-gray-200: hsl(0, 0%, 77%);
+  --color-gray-300: hsl(0, 0%, 67%);
+  --color-gray-400: hsl(0, 0%, 60%);
+  --color-gray-500: hsl(0, 0%, 50%);
+  --color-blue-100: hsl(234, 19%, 40%);
+  --color-blue-200: hsl(234, 18%, 30%);
+  --color-blue-300: hsl(234, 18%, 20%);
+  --color-background-100: hsl(0, 0%, 99%);
+  --color-background-200: hsl(0, 0%, 97%);
+  --color-background-300: hsl(0, 0%, 94%);
+  --color-line-100: hsl(0, 0%, 95%);
+  --color-line-200: hsl(0, 0%, 90%);
+  --color-error: hsl(15, 100%, 49%);
+  --color-mint-50: hsl(171, 86%, 88%);
+  --color-mint-100: hsl(171, 86%, 68%);
+  --color-mint-200: hsl(171, 86%, 58%);
+  --color-mint-300: hsl(171, 86%, 48%);
+  --color-mint-400: hsl(171, 86%, 38%);
 
   --text-xs: 0.75rem;
   --text-xs--line-height: 1.25rem;

--- a/src/app/test/hyeran/page.tsx
+++ b/src/app/test/hyeran/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState } from "react";
+
+import RadioButton from "@/shared/components/common/button/RadioButton";
+
+const Hyeran = () => {
+  const [selected, setSelected] = useState("");
+  const [selectedMd, setSelectedMd] = useState("");
+  const options = [
+    { value: "REJECTED", label: "거절" },
+    { value: "INTERVIEW_PENDING", label: "면접대기" },
+    { value: "INTERVIEW_COMPLETED", label: "면접 완료" },
+    { value: "HIRED", label: "채용 완료", disabled: true },
+  ];
+  return (
+    <div className="flex flex-col gap-10">
+      <h1>라디오 버튼 컴포넌트</h1>
+      <h3>Size : sm</h3>
+      <RadioButton
+        legend="현재 진행상태를 알려주세요."
+        name="applicationStatus"
+        options={options}
+        size="sm"
+        value={selected}
+        onChange={setSelected}
+      />
+      <hr />
+      <h3>Size : md</h3>
+      <RadioButton
+        legend="현재 진행상태를 알려주세요."
+        name="applicationStatus_md"
+        options={options}
+        size="md"
+        value={selectedMd}
+        onChange={setSelectedMd}
+      />
+    </div>
+  );
+};
+
+export default Hyeran;

--- a/src/app/test/hyeran/page.tsx
+++ b/src/app/test/hyeran/page.tsx
@@ -1,37 +1,37 @@
-"use client";
+'use client';
 
-import { useState } from "react";
+import { useState } from 'react';
 
-import RadioButton from "@/shared/components/common/button/RadioButton";
+import RadioButton from '@/shared/components/common/button/RadioButton';
 
 const Hyeran = () => {
-  const [selected, setSelected] = useState("");
-  const [selectedMd, setSelectedMd] = useState("");
+  const [selected, setSelected] = useState('');
+  const [selectedMd, setSelectedMd] = useState('');
   const options = [
-    { value: "REJECTED", label: "거절" },
-    { value: "INTERVIEW_PENDING", label: "면접대기" },
-    { value: "INTERVIEW_COMPLETED", label: "면접 완료" },
-    { value: "HIRED", label: "채용 완료", disabled: true },
+    { value: 'REJECTED', label: '거절' },
+    { value: 'INTERVIEW_PENDING', label: '면접대기' },
+    { value: 'INTERVIEW_COMPLETED', label: '면접 완료' },
+    { value: 'HIRED', label: '채용 완료', disabled: true },
   ];
   return (
-    <div className="flex flex-col gap-10">
+    <div className='flex flex-col gap-10'>
       <h1>라디오 버튼 컴포넌트</h1>
       <h3>Size : sm</h3>
       <RadioButton
-        legend="현재 진행상태를 알려주세요."
-        name="applicationStatus"
+        legend='현재 진행상태를 알려주세요.'
+        name='applicationStatus'
         options={options}
-        size="sm"
+        size='sm'
         value={selected}
         onChange={setSelected}
       />
       <hr />
       <h3>Size : md</h3>
       <RadioButton
-        legend="현재 진행상태를 알려주세요."
-        name="applicationStatus_md"
+        legend='현재 진행상태를 알려주세요.'
+        name='applicationStatus_md'
         options={options}
-        size="md"
+        size='md'
         value={selectedMd}
         onChange={setSelectedMd}
       />

--- a/src/app/test/hyeran/page.tsx
+++ b/src/app/test/hyeran/page.tsx
@@ -6,7 +6,6 @@ import RadioButton from '@/shared/components/common/button/RadioButton';
 
 const Hyeran = () => {
   const [selected, setSelected] = useState('');
-  const [selectedMd, setSelectedMd] = useState('');
   const options = [
     { value: 'REJECTED', label: '거절' },
     { value: 'INTERVIEW_PENDING', label: '면접대기' },
@@ -16,24 +15,12 @@ const Hyeran = () => {
   return (
     <div className='flex flex-col gap-10'>
       <h1>라디오 버튼 컴포넌트</h1>
-      <h3>Size : sm</h3>
       <RadioButton
         legend='현재 진행상태를 알려주세요.'
         name='applicationStatus'
         options={options}
-        size='sm'
         value={selected}
         onChange={setSelected}
-      />
-      <hr />
-      <h3>Size : md</h3>
-      <RadioButton
-        legend='현재 진행상태를 알려주세요.'
-        name='applicationStatus_md'
-        options={options}
-        size='md'
-        value={selectedMd}
-        onChange={setSelectedMd}
       />
     </div>
   );

--- a/src/shared/components/common/button/RadioButton.tsx
+++ b/src/shared/components/common/button/RadioButton.tsx
@@ -75,15 +75,9 @@ const RadioButton = ({ name, options, value, onChange, disabled = false, legend 
           return (
             <label
               key={option.value}
-              className={`lg:py-17 lg:w-360 w-327 flex cursor-pointer items-center justify-between rounded-lg border-2 p-14 font-medium transition-all duration-200 lg:px-24 ${
-                isChecked ? 'border-mint-300 bg-gray-50' : 'border-line-100 hover:border-mint-300 bg-white'
-              } ${isDisabled ? 'cursor-not-allowed opacity-50' : ''} `}
+              className='lg:py-17 w-327 lg:w-360 has-[:checked]:border-mint-300 border-line-100 has-[:disabled]:hover:border-line-100 hover:border-mint-300 flex cursor-pointer items-center justify-between rounded-lg border-2 bg-white p-14 font-medium transition-all duration-200 has-[:disabled]:cursor-not-allowed has-[:checked]:bg-gray-50 has-[:disabled]:opacity-50 lg:px-24'
             >
-              <span
-                className={`flex-1 select-none text-sm lg:text-base ${isDisabled ? 'text-gray-400' : 'text-gray-600'}`}
-              >
-                {option.label}
-              </span>
+              <span className='flex-1 select-none text-sm text-gray-600 lg:text-base'>{option.label}</span>
               <div className='relative inline-block'>
                 <input
                   checked={isChecked}
@@ -96,7 +90,7 @@ const RadioButton = ({ name, options, value, onChange, disabled = false, legend 
                     onChange(e.target.value);
                   }}
                 />
-                {isChecked && <div className='bg-mint-300 absolute left-6 top-6 h-10 w-10 rounded-full' />}
+                {isChecked && <div className='bg-mint-300 absolute left-6 top-6 size-10 rounded-full' />}
               </div>
             </label>
           );

--- a/src/shared/components/common/button/RadioButton.tsx
+++ b/src/shared/components/common/button/RadioButton.tsx
@@ -1,6 +1,6 @@
-"use client";
+'use client';
 
-import { JSX } from "react";
+import { JSX } from 'react';
 
 export interface RadioOption {
   value: string;
@@ -17,7 +17,7 @@ export interface RadioButtonProps {
   onChange: (value: string) => void;
   disabled?: boolean;
   legend?: string;
-  size?: "sm" | "md";
+  size?: 'sm' | 'md';
 }
 
 /**
@@ -73,16 +73,16 @@ const RadioButton = ({
   onChange,
   disabled = false,
   legend,
-  size = "sm",
+  size = 'sm',
 }: RadioButtonProps): JSX.Element => {
   const sizeStyle = {
     sm: {
-      button: "p-14 text-sm rounded-lg w-[327px]",
-      text: "text-sm",
+      button: 'p-14 text-sm rounded-lg w-[327px]',
+      text: 'text-sm',
     },
     md: {
-      button: "px-24 py-17 text-lg rounded-lg w-[360px]",
-      text: "text-base",
+      button: 'px-24 py-17 text-lg rounded-lg w-[360px]',
+      text: 'text-base',
     },
   };
 
@@ -90,54 +90,36 @@ const RadioButton = ({
 
   return (
     <fieldset>
-      {legend && <legend className="sr-only">{legend}</legend>}
-      <div className="flex flex-col gap-8">
+      {legend && <legend className='sr-only'>{legend}</legend>}
+      <div className='flex flex-col gap-8'>
         {options.map((option) => {
           const isDisabled = disabled || option.disabled;
           const isChecked = value === option.value;
           return (
             <label
               key={option.value}
-              className={`
-                  ${currentSize.button}
-                  border-2 cursor-pointer transition-all duration-200 font-medium
-                  flex items-center justify-between
-                  ${
-                    isChecked
-                      ? "border-mint-300 bg-gray-50"
-                      : "border-line-100 bg-white hover:border-mint-300"
-                  }
-                  ${isDisabled ? "opacity-50 cursor-not-allowed" : ""}
-                `}
+              className={` ${currentSize.button} flex cursor-pointer items-center justify-between border-2 font-medium transition-all duration-200 ${
+                isChecked ? 'border-mint-300 bg-gray-50' : 'border-line-100 hover:border-mint-300 bg-white'
+              } ${isDisabled ? 'cursor-not-allowed opacity-50' : ''} `}
             >
               <span
-                className={`${currentSize.text} ${isDisabled ? "text-gray-400" : "text-gray-600"} flex-1 select-none`}
+                className={`${currentSize.text} ${isDisabled ? 'text-gray-400' : 'text-gray-600'} flex-1 select-none`}
               >
                 {option.label}
               </span>
-              <div className="relative inline-block">
+              <div className='relative inline-block'>
                 <input
                   checked={isChecked}
-                  className="
-                    w-22 h-22
-                    appearance-none rounded-full border border-gray-200 bg-white
-                    checked:border-mint-300 checked:bg-white
-                    disabled:opacity-50 disabled:cursor-not-allowed
-                    transition-all duration-200
-                    cursor-pointer
-                    block
-                  "
+                  className='w-22 h-22 checked:border-mint-300 block cursor-pointer appearance-none rounded-full border border-gray-200 bg-white transition-all duration-200 checked:bg-white disabled:cursor-not-allowed disabled:opacity-50'
                   disabled={isDisabled}
                   name={name}
-                  type="radio"
+                  type='radio'
                   value={option.value}
                   onChange={(e) => {
                     onChange(e.target.value);
                   }}
                 />
-                {isChecked && (
-                  <div className="absolute top-6 left-6 w-10 h-10 bg-mint-300 rounded-full" />
-                )}
+                {isChecked && <div className='bg-mint-300 absolute left-6 top-6 h-10 w-10 rounded-full' />}
               </div>
             </label>
           );

--- a/src/shared/components/common/button/RadioButton.tsx
+++ b/src/shared/components/common/button/RadioButton.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { JSX } from "react";
+
+export interface RadioOption {
+  value: string;
+  /** 화면에 표시될 라벨 */
+  label: string;
+  /** 개별 옵션 비활성화 여부 */
+  disabled?: boolean;
+}
+
+export interface RadioButtonProps {
+  name: string;
+  options: RadioOption[];
+  value?: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  legend?: string;
+  size?: "sm" | "md";
+}
+
+/**
+ * 라디오 버튼 그룹 컴포넌트
+ *
+ * @description
+ * 버튼 형태의 라디오 버튼 그룹을 제공합니다.
+ * 접근성을 고려하여 fieldset과 legend를 사용합니다.
+ *
+ * @example
+ * ```tsx
+ * import { useState } from 'react';
+ * import RadioButton from '@/shared/components/common/button/RadioButton';
+ *
+ * const MyComponent = () => {
+ *   const [selected, setSelected] = useState('');
+ *   const options = [
+ *     { value: 'REJECTED', label: '거절' },
+ *     { value: 'INTERVIEW_PENDING', label: '면접대기' },
+ *     { value: 'INTERVIEW_COMPLETED', label: '면접 완료' },
+ *     { value: 'HIRED', label: '채용 완료', disabled: true },
+ *   ];
+ *
+ *   return (
+ *     <RadioButton
+ *       legend="현재 진행상태를 알려주세요."
+ *       name="applicationStatus"
+ *       options={options}
+ *       size="sm"
+ *       value={selected}
+ *       onChange={setSelected}
+ *     />
+ *   );
+ * };
+ * ```
+ *
+ * @example
+ * // 비활성화된 전체 그룹
+ * ```tsx
+ * <RadioButton
+ *   name="status"
+ *   options={options}
+ *   value={selected}
+ *   onChange={setSelected}
+ *   disabled={true}
+ * />
+ * ```
+ */
+const RadioButton = ({
+  name,
+  options,
+  value,
+  onChange,
+  disabled = false,
+  legend,
+  size = "sm",
+}: RadioButtonProps): JSX.Element => {
+  const sizeStyle = {
+    sm: {
+      button: "p-14 text-sm rounded-lg w-[327px]",
+      text: "text-sm",
+    },
+    md: {
+      button: "px-24 py-17 text-lg rounded-lg w-[360px]",
+      text: "text-base",
+    },
+  };
+
+  const currentSize = sizeStyle[size];
+
+  return (
+    <fieldset>
+      {legend && <legend className="sr-only">{legend}</legend>}
+      <div className="flex flex-col gap-8">
+        {options.map((option) => {
+          const isDisabled = disabled || option.disabled;
+          const isChecked = value === option.value;
+          return (
+            <label
+              key={option.value}
+              className={`
+                  ${currentSize.button}
+                  border-2 cursor-pointer transition-all duration-200 font-medium
+                  flex items-center justify-between
+                  ${
+                    isChecked
+                      ? "border-mint-300 bg-gray-50"
+                      : "border-line-100 bg-white hover:border-mint-300"
+                  }
+                  ${isDisabled ? "opacity-50 cursor-not-allowed" : ""}
+                `}
+            >
+              <span
+                className={`${currentSize.text} ${isDisabled ? "text-gray-400" : "text-gray-600"} flex-1 select-none`}
+              >
+                {option.label}
+              </span>
+              <div className="relative inline-block">
+                <input
+                  checked={isChecked}
+                  className="
+                    w-22 h-22
+                    appearance-none rounded-full border border-gray-200 bg-white
+                    checked:border-mint-300 checked:bg-white
+                    disabled:opacity-50 disabled:cursor-not-allowed
+                    transition-all duration-200
+                    cursor-pointer
+                    block
+                  "
+                  disabled={isDisabled}
+                  name={name}
+                  type="radio"
+                  value={option.value}
+                  onChange={(e) => {
+                    onChange(e.target.value);
+                  }}
+                />
+                {isChecked && (
+                  <div className="absolute top-6 left-6 w-10 h-10 bg-mint-300 rounded-full" />
+                )}
+              </div>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+};
+
+export default RadioButton;

--- a/src/shared/components/common/button/RadioButton.tsx
+++ b/src/shared/components/common/button/RadioButton.tsx
@@ -17,7 +17,6 @@ export interface RadioButtonProps {
   onChange: (value: string) => void;
   disabled?: boolean;
   legend?: string;
-  size?: 'sm' | 'md';
 }
 
 /**
@@ -46,7 +45,6 @@ export interface RadioButtonProps {
  *       legend="현재 진행상태를 알려주세요."
  *       name="applicationStatus"
  *       options={options}
- *       size="sm"
  *       value={selected}
  *       onChange={setSelected}
  *     />
@@ -66,28 +64,7 @@ export interface RadioButtonProps {
  * />
  * ```
  */
-const RadioButton = ({
-  name,
-  options,
-  value,
-  onChange,
-  disabled = false,
-  legend,
-  size = 'sm',
-}: RadioButtonProps): JSX.Element => {
-  const sizeStyle = {
-    sm: {
-      button: 'p-14 text-sm rounded-lg w-[327px]',
-      text: 'text-sm',
-    },
-    md: {
-      button: 'px-24 py-17 text-lg rounded-lg w-[360px]',
-      text: 'text-base',
-    },
-  };
-
-  const currentSize = sizeStyle[size];
-
+const RadioButton = ({ name, options, value, onChange, disabled = false, legend }: RadioButtonProps): JSX.Element => {
   return (
     <fieldset>
       {legend && <legend className='sr-only'>{legend}</legend>}
@@ -98,12 +75,12 @@ const RadioButton = ({
           return (
             <label
               key={option.value}
-              className={` ${currentSize.button} flex cursor-pointer items-center justify-between border-2 font-medium transition-all duration-200 ${
+              className={`lg:py-17 lg:w-360 w-327 flex cursor-pointer items-center justify-between rounded-lg border-2 p-14 font-medium transition-all duration-200 lg:px-24 ${
                 isChecked ? 'border-mint-300 bg-gray-50' : 'border-line-100 hover:border-mint-300 bg-white'
               } ${isDisabled ? 'cursor-not-allowed opacity-50' : ''} `}
             >
               <span
-                className={`${currentSize.text} ${isDisabled ? 'text-gray-400' : 'text-gray-600'} flex-1 select-none`}
+                className={`flex-1 select-none text-sm lg:text-base ${isDisabled ? 'text-gray-400' : 'text-gray-600'}`}
               >
                 {option.label}
               </span>


### PR DESCRIPTION
## 📝 PR 내용 요약

- 버튼 형태의 라디오 버튼 컴포넌트 구현
- 개별 옵션 및 전체 그룹 비활성화 기능
- fieldset과 legend를 활용한 시맨틱 구조
- 스크린 리더 지원 (sr-only 클래스)
- 반응형으로 구현

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #11 

---

## 📸 스크린샷 (선택)

<img width="399" height="635" alt="image" src="https://github.com/user-attachments/assets/3b6f2582-1e3d-4ab9-9e29-8f9e25cdb8d0" />

---

## 💬 참고 사항
- 사용 예시
```tsx
const [selected, setSelected] = useState('');
const options = [
  { value: 'REJECTED', label: '거절' },
  { value: 'INTERVIEW_PENDING', label: '면접대기' },
  { value: 'INTERVIEW_COMPLETED', label: '면접 완료' },
  { value: 'HIRED', label: '채용 완료', disabled: true },
];

<RadioButton
  legend='현재 진행상태를 알려주세요.'
  name='applicationStatus'
  options={options}
  value={selected}
  onChange={setSelected}
/>
```
- legend는 `sr-only` 속성이 있어 화면에는 보이지 않지만, 스크린 리더를 통해 접근성을 높였습니다.
- 반응형으로 구현되어 PC: `w-360` / MO, TA: `w-327`로 적용됩니다.
---
