### PR TITLE
[feat] Tab 버튼 컴포넌트 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 /* 다크모드 클래스 사용을 위한 custom-varient 선언 */
 @custom-variant dark (&:is(.dark *));
@@ -10,7 +10,8 @@
   --color-black-300: hsl(0, 0%, 22%);
   --color-black-400: hsl(0, 0%, 12%);
   --color-black-500: hsl(0, 0%, 2%);
-  --color-gray-50: hsl(0, 0%, 92%);
+  --color-gray-25: hsl(0, 0%, 97%);
+  --color-gray-50: hsl(0, 0%, 93%);
   --color-gray-100: hsl(0, 0%, 87%);
   --color-gray-200: hsl(0, 0%, 77%);
   --color-gray-300: hsl(0, 0%, 67%);

--- a/src/app/test/yujin/page.tsx
+++ b/src/app/test/yujin/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import MainGnb from '@components/common/gnb/MainGnb';
+
 import AuthGnb from '@/shared/components/common/gnb/AuthGnb';
-import MainGnb from '@/shared/components/common/gnb/MainGnb';
-import ThemeToggle from '@/shared/components/ThemeToggle';
+import Tab from '@/shared/components/common/tap/Tab';
 
 const TestPage = () => {
   return (
-    <div className="text-md m-16">
+    <div className="m-16 flex flex-col gap-24 text-md">
       <ul>
         <li className="mb-36">
           로그인 전 헤더
@@ -18,10 +19,11 @@ const TestPage = () => {
         </li>
       </ul>
 
-      <p className="">layer</p>
+      <p className="bg-blue-500">layer</p>
       <div className="bg-gray-200">Hello Mint</div>
       <div className="BG-lightmint">Mint</div>
-      <ThemeToggle />
+
+      <Tab />
     </div>
   );
 };

--- a/src/shared/components/ThemeToggle.tsx
+++ b/src/shared/components/ThemeToggle.tsx
@@ -10,14 +10,14 @@ const ThemeToggle = () => {
   useEffect(() => setMounted(true), []);
 
   if (!mounted) return null;
-    
+
   const isDark = theme === 'dark';
 
   return (
     <div>
       <button
         aria-label="Toggle Dark Mode"
-        className="dark-light-toggle BG-ToggleButton relative flex h-26 w-26 cursor-pointer items-center justify-center rounded-full transition-colors duration-500"
+        className="dark-light-toggle BG-ToggleButton relative flex h-26 w-26 cursor-pointer items-center justify-center rounded-full transition-colors duration-500 md:h-32 md:w-32 lg:h-36 lg:w-36"
         type="button"
         onClick={() => setTheme(isDark ? 'light' : 'dark')}
       >
@@ -47,7 +47,6 @@ const ThemeToggle = () => {
           className={`absolute h-16 w-16 transform text-black transition-opacity duration-500 ease-in-out ${
             isDark
               ? 'translate-x-[-2px] translate-y-1 scale-105 opacity-100'
-
               : 'scale-90 opacity-0'
           }`}
           fill="currentColor"

--- a/src/shared/components/common/gnb-menu/GnbMenu.tsx
+++ b/src/shared/components/common/gnb-menu/GnbMenu.tsx
@@ -18,12 +18,12 @@ const GnbMenu = ({ isOpen, setIsOpen }: GnbMenuProps) => {
       )}
 
       <div
-        className={`dark:bg-black-400 fixed top-0 right-0 z-50 h-full w-220 transform bg-white opacity-95 shadow-lg transition-transform duration-300 ease-in-out md:w-300 ${
+        className={`fixed top-0 right-0 z-50 h-full w-220 transform bg-white opacity-95 shadow-lg transition-transform duration-300 ease-in-out md:w-300 dark:bg-black-400 ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
-        <div className="mt-32 flex flex-col gap-32 p-4">
-          <div className="border-b border-gray-200">
+        <div className="mt-32 flex flex-col gap-56 p-4">
+          <div className="border-b border-gray-500 pb-12">
             {/* 닫기 버튼 (우측 상단 고정) */}
             <button
               aria-label="메뉴 닫기"

--- a/src/shared/components/common/gnb/AuthGnb.tsx
+++ b/src/shared/components/common/gnb/AuthGnb.tsx
@@ -5,6 +5,8 @@ import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
+import MobileNav from './MobileNav';
+
 const AuthGnb = () => {
   const [mounted, setMounted] = useState(false);
   const pathname = usePathname();
@@ -14,52 +16,56 @@ const AuthGnb = () => {
   if (!mounted) return null;
 
   return (
-    <header className="w-full border-b border-gray-400 md:px-72 lg:px-120 dark:border-gray-500">
-      <div className="mx-auto flex max-w-7xl items-center justify-center px-4 md:justify-between md:py-3">
-        {/* 좌측 영역 */}
-        <div className="flex items-center md:gap-24">
-          {/* 로고 */}
-          <button
-            className="flex cursor-pointer items-center space-x-2 py-15 text-xl font-bold md:py-24"
-            type="button"
-            onClick={() => router.push('/')}
-          >
-            <div className="relative mr-16 h-20 w-20 md:mr-12 md:h-24 md:w-24 lg:h-40 lg:w-40">
-              <Image fill alt="로고 이미지" src="/images/logo.svg" />
-            </div>
-            <div className="relative h-24 w-124 lg:h-36 lg:w-200">
-              <Image fill alt="로고 명" src="/images/logo-typo.svg" />
-            </div>
-          </button>
-        </div>
+    <>
+      {/* 상단 헤더 */}
+      <header className="w-full border-b border-gray-400 md:px-72 lg:px-120 dark:border-gray-500">
+        <div className="mx-auto flex max-w-7xl items-center justify-center px-4 md:justify-between md:py-3">
+          {/* 좌측 로고 */}
+          <div className="flex items-center md:gap-24">
+            <button
+              className="flex cursor-pointer items-center space-x-2 py-15 text-xl font-bold md:py-24"
+              type="button"
+              onClick={() => router.push('/')}
+            >
+              <div className="relative mr-16 h-20 w-20 md:mr-12 md:h-24 md:w-24 lg:h-40 lg:w-40">
+                <Image fill alt="로고 이미지" src="/images/logo.svg" />
+              </div>
+              <div className="relative h-24 w-124 lg:h-36 lg:w-200">
+                <Image fill alt="로고 명" src="/images/logo-typo.svg" />
+              </div>
+            </button>
+          </div>
 
-        {/* 우측 영역 */}
-        <div className="hidden items-center gap-24 md:flex">
-          {/* 네비게이션 메뉴 */}
-          <nav className="text-16 mr-16 flex gap-24 font-medium md:text-xs lg:text-sm lg:text-[20px]">
-            <button
-              className={`hover:text-primary cursor-pointer border-none bg-transparent p-0 text-inherit transition-colors ${
-                pathname === '/owner' ? 'text-mint-100' : ''
-              }`}
-              type="button"
-              onClick={() => router.push('/owner')}
-            >
-              사장님 전용
-            </button>
-            <button
-              className={`hover:text-primary cursor-pointer border-none bg-transparent p-0 text-inherit transition-colors ${
-                pathname === '/worker' ? 'text-mint-100' : ''
-              }`}
-              type="button"
-              onClick={() => router.push('/worker')}
-            >
-              지원자 전용
-            </button>
-          </nav>
-          <ThemeToggle />
+          {/* 우측 (데스크탑용) */}
+          <div className="hidden items-center gap-24 md:flex">
+            <nav className="text-16 mr-16 flex gap-24 font-medium md:text-xs lg:text-sm lg:text-[20px]">
+              <button
+                className={`hover:text-primary cursor-pointer border-none bg-transparent p-0 text-inherit transition-colors ${
+                  pathname === '/owner' ? 'text-mint-100' : ''
+                }`}
+                type="button"
+                onClick={() => router.push('/owner')}
+              >
+                사장님 전용
+              </button>
+              <button
+                className={`hover:text-primary cursor-pointer border-none bg-transparent p-0 text-inherit transition-colors ${
+                  pathname === '/worker' ? 'text-mint-100' : ''
+                }`}
+                type="button"
+                onClick={() => router.push('/worker')}
+              >
+                지원자 전용
+              </button>
+            </nav>
+            <ThemeToggle />
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
+
+      {/* 모바일 전용 메뉴 */}
+      <MobileNav />
+    </>
   );
 };
 

--- a/src/shared/components/common/gnb/AuthGnb.tsx
+++ b/src/shared/components/common/gnb/AuthGnb.tsx
@@ -14,7 +14,7 @@ const AuthGnb = () => {
   if (!mounted) return null;
 
   return (
-    <header className="w-full border-b border-gray-200 md:px-72 lg:px-120 dark:border-gray-500">
+    <header className="w-full border-b border-gray-400 md:px-72 lg:px-120 dark:border-gray-500">
       <div className="mx-auto flex max-w-7xl items-center justify-center px-4 md:justify-between md:py-3">
         {/* 좌측 영역 */}
         <div className="flex items-center md:gap-24">

--- a/src/shared/components/common/gnb/AuthGnb.tsx
+++ b/src/shared/components/common/gnb/AuthGnb.tsx
@@ -14,7 +14,7 @@ const AuthGnb = () => {
   if (!mounted) return null;
 
   return (
-    <header className="w-full border-b border-gray-200 md:px-16 md:px-72 lg:px-120 dark:border-gray-500">
+    <header className="w-full border-b border-gray-200 md:px-72 lg:px-120 dark:border-gray-500">
       <div className="mx-auto flex max-w-7xl items-center justify-center px-4 md:justify-between md:py-3">
         {/* 좌측 영역 */}
         <div className="flex items-center md:gap-24">
@@ -24,7 +24,7 @@ const AuthGnb = () => {
             type="button"
             onClick={() => router.push('/')}
           >
-            <div className="relative mr-8 h-16 w-16 md:mr-6 md:h-24 md:w-24 lg:h-36 lg:w-36">
+            <div className="relative mr-16 h-20 w-20 md:mr-12 md:h-24 md:w-24 lg:h-36 lg:w-36">
               <Image fill alt="로고 이미지" src="/images/logo.svg" />
             </div>
             <div className="relative h-24 w-124 lg:h-36 lg:w-212">

--- a/src/shared/components/common/gnb/AuthGnb.tsx
+++ b/src/shared/components/common/gnb/AuthGnb.tsx
@@ -14,32 +14,34 @@ const AuthGnb = () => {
   if (!mounted) return null;
 
   return (
-    <header className="w-full border-b border-gray-200 px-12 md:px-32 dark:border-gray-500">
+    <header className="w-full border-b border-gray-200 md:px-16 md:px-72 lg:px-120 dark:border-gray-500">
       <div className="mx-auto flex max-w-7xl items-center justify-center px-4 md:justify-between md:py-3">
         {/* 좌측 영역 */}
         <div className="flex items-center md:gap-24">
           {/* 로고 */}
           <button
-            className="flex items-center space-x-2 text-xl font-bold"
+            className="flex cursor-pointer items-center space-x-2 py-15 text-xl font-bold md:py-24"
+            type="button"
             onClick={() => router.push('/')}
           >
-            <div className="relative mr-8 h-16 w-16 md:mr-6 md:h-24 md:w-24">
+            <div className="relative mr-8 h-16 w-16 md:mr-6 md:h-24 md:w-24 lg:h-36 lg:w-36">
               <Image fill alt="로고 이미지" src="/images/logo.svg" />
             </div>
-            <div className="relative h-24 w-70 md:h-40 md:w-100">
+            <div className="relative h-24 w-124 lg:h-36 lg:w-212">
               <Image fill alt="로고 명" src="/images/logo-typo.svg" />
             </div>
           </button>
         </div>
 
         {/* 우측 영역 */}
-        <div className="hidden items-center gap-4 md:flex">
+        <div className="hidden items-center gap-24 md:flex">
           {/* 네비게이션 메뉴 */}
-          <nav className="mr-16 flex gap-12 text-xs font-medium md:text-xs lg:text-sm">
+          <nav className="text-16 mr-16 flex gap-24 font-medium md:text-xs lg:text-sm lg:text-[20px]">
             <button
               className={`hover:text-primary cursor-pointer border-none bg-transparent p-0 text-inherit transition-colors ${
                 pathname === '/owner' ? 'text-mint-100' : ''
               }`}
+              type="button"
               onClick={() => router.push('/owner')}
             >
               사장님 전용
@@ -48,6 +50,7 @@ const AuthGnb = () => {
               className={`hover:text-primary cursor-pointer border-none bg-transparent p-0 text-inherit transition-colors ${
                 pathname === '/worker' ? 'text-mint-100' : ''
               }`}
+              type="button"
               onClick={() => router.push('/worker')}
             >
               지원자 전용

--- a/src/shared/components/common/gnb/AuthGnb.tsx
+++ b/src/shared/components/common/gnb/AuthGnb.tsx
@@ -24,10 +24,10 @@ const AuthGnb = () => {
             type="button"
             onClick={() => router.push('/')}
           >
-            <div className="relative mr-16 h-20 w-20 md:mr-12 md:h-24 md:w-24 lg:h-36 lg:w-36">
+            <div className="relative mr-16 h-20 w-20 md:mr-12 md:h-24 md:w-24 lg:h-40 lg:w-40">
               <Image fill alt="로고 이미지" src="/images/logo.svg" />
             </div>
-            <div className="relative h-24 w-124 lg:h-36 lg:w-212">
+            <div className="relative h-24 w-124 lg:h-36 lg:w-200">
               <Image fill alt="로고 명" src="/images/logo-typo.svg" />
             </div>
           </button>

--- a/src/shared/components/common/gnb/MainGnb.tsx
+++ b/src/shared/components/common/gnb/MainGnb.tsx
@@ -20,7 +20,7 @@ const MainGnb = () => {
   if (!mounted) return null;
 
   return (
-    <header className="w-full border-b border-gray-200 px-24 md:px-72 dark:border-gray-500">
+    <header className="w-full border-b border-gray-400 px-24 md:px-72 dark:border-gray-500">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6 md:py-3">
         {/* 좌측 영역 */}
         <div className="flex items-center md:gap-32 lg:gap-48">

--- a/src/shared/components/common/gnb/MainGnb.tsx
+++ b/src/shared/components/common/gnb/MainGnb.tsx
@@ -33,7 +33,7 @@ const MainGnb = () => {
             <div className="relative mr-24 h-20 w-20 md:mr-12 md:h-24 md:w-24 lg:mr-16 lg:h-36 lg:w-36">
               <Image fill alt="로고 이미지" src="/images/logo.svg" />
             </div>
-            <div className="relative hidden h-24 w-124 md:flex lg:h-36 lg:w-212">
+            <div className="relative hidden h-24 w-124 md:flex lg:h-36 lg:w-200">
               <Image fill alt="로고 명" src="/images/logo-typo.svg" />
             </div>
           </button>

--- a/src/shared/components/common/gnb/MainGnb.tsx
+++ b/src/shared/components/common/gnb/MainGnb.tsx
@@ -30,10 +30,10 @@ const MainGnb = () => {
             type="button"
             onClick={() => router.push('/')}
           >
-            <div className="relative mr-24 h-16 w-16 md:mr-6 md:h-24 md:w-24 lg:h-36 lg:w-36">
+            <div className="relative mr-24 h-20 w-20 md:mr-12 md:h-24 md:w-24 lg:mr-16 lg:h-36 lg:w-36">
               <Image fill alt="로고 이미지" src="/images/logo.svg" />
             </div>
-            <div className="md: relative hidden h-24 w-124 md:flex lg:h-36 lg:w-212">
+            <div className="relative hidden h-24 w-124 md:flex lg:h-36 lg:w-212">
               <Image fill alt="로고 명" src="/images/logo-typo.svg" />
             </div>
           </button>

--- a/src/shared/components/common/gnb/MainGnb.tsx
+++ b/src/shared/components/common/gnb/MainGnb.tsx
@@ -20,29 +20,31 @@ const MainGnb = () => {
   if (!mounted) return null;
 
   return (
-    <header className="w-full border-b border-gray-200 px-12 md:px-32 dark:border-gray-500">
+    <header className="w-full border-b border-gray-200 px-24 md:px-72 dark:border-gray-500">
       <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6 md:py-3">
         {/* 좌측 영역 */}
-        <div className="flex items-center md:gap-24">
+        <div className="flex items-center md:gap-32 lg:gap-48">
           {/* 로고 */}
           <button
-            className="flex items-center space-x-2 text-xl font-bold"
+            className="flex cursor-pointer items-center space-x-2 py-15 text-xl font-bold md:py-24"
+            type="button"
             onClick={() => router.push('/')}
           >
-            <div className="relative mr-24 h-16 w-16 md:mr-6 md:h-24 md:w-24">
+            <div className="relative mr-24 h-16 w-16 md:mr-6 md:h-24 md:w-24 lg:h-36 lg:w-36">
               <Image fill alt="로고 이미지" src="/images/logo.svg" />
             </div>
-            <div className="md: relative hidden h-40 w-100 md:flex">
+            <div className="md: relative hidden h-24 w-124 md:flex lg:h-36 lg:w-212">
               <Image fill alt="로고 명" src="/images/logo-typo.svg" />
             </div>
           </button>
 
           {/* 네비게이션 메뉴 */}
-          <nav className="flex gap-6 text-[10px] font-medium md:text-xs lg:text-sm">
+          <nav className="flex gap-16 text-[14px] font-medium md:gap-24 md:text-[16px] lg:text-[20px]">
             <button
               className={`hover:text-primary cursor-pointer border-none bg-transparent p-0 text-inherit transition-colors ${
                 pathname === '/albalist' ? 'text-mint-100' : ''
               }`}
+              type="button"
               onClick={() => router.push('/albalist')}
             >
               알바 목록
@@ -67,11 +69,12 @@ const MainGnb = () => {
         </div>
 
         {/* 우측 영역 */}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-12">
           <ThemeToggle />
           <button
             aria-label="메뉴 열기/닫기"
-            className="relative h-24 w-24 cursor-pointer"
+            className="relative h-24 w-24 cursor-pointer md:h-36 md:w-36"
+            type="button"
             onClick={() => setIsOpen(!isOpen)}
           >
             <Image

--- a/src/shared/components/common/gnb/MobileNav.tsx
+++ b/src/shared/components/common/gnb/MobileNav.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+
+const MobileNav = () => {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  // 숨기고 싶은 경로 배열
+  const hiddenRoutes = ['/owner/info', '/worker/info'];
+
+  // prefix 방식으로 처리
+  const shouldHide =
+    hiddenRoutes.includes(pathname) || pathname.includes('/info');
+
+  if (shouldHide) return null;
+
+  return (
+    <nav className="flex justify-center gap-32 py-12 md:hidden dark:border-gray-500">
+      <button
+        className={`hover:text-primary text-sm font-medium transition-colors ${
+          pathname === '/owner'
+            ? 'text-mint-100'
+            : 'text-gray-700 dark:text-white'
+        }`}
+        type="button"
+        onClick={() => router.push('/owner')}
+      >
+        사장님 전용
+      </button>
+      <button
+        className={`hover:text-primary text-sm font-medium transition-colors ${
+          pathname === '/worker'
+            ? 'text-mint-100'
+            : 'text-gray-700 dark:text-white'
+        }`}
+        type="button"
+        onClick={() => router.push('/worker')}
+      >
+        지원자 전용
+      </button>
+    </nav>
+  );
+};
+
+export default MobileNav;

--- a/src/shared/components/common/tap/Tab.tsx
+++ b/src/shared/components/common/tap/Tab.tsx
@@ -1,0 +1,17 @@
+const Tab = () => {
+  return (
+    <div className="flex w-327 gap-8 rounded-md bg-gray-25 p-6 text-[14px] md:w-422 md:text-[16px]">
+      <div className="rounded-md bg-white px-23 py-4 text-black md:px-35 md:py-8">
+        내가 쓴 글
+      </div>
+      <div className="rounded-md bg-white px-23 py-4 text-black md:px-35 md:py-8">
+        내가 쓴 댓글
+      </div>
+      <div className="rounded-md bg-white px-23 py-4 text-black md:px-35 md:py-8">
+        스크랩
+      </div>
+    </div>
+  );
+};
+
+export default Tab;

--- a/src/shared/components/common/tap/Tab.tsx
+++ b/src/shared/components/common/tap/Tab.tsx
@@ -1,15 +1,20 @@
+import { useState } from 'react';
+
 const Tab = () => {
+  const tabs = ['내가 쓴 글', '내가 쓴 댓글', '스크랩'];
+  const [activeTab, setActiveTab] = useState(0);
+
   return (
     <div className="flex w-327 gap-8 rounded-md bg-gray-25 p-6 text-[14px] md:w-422 md:text-[16px]">
-      <div className="rounded-md bg-white px-23 py-4 text-black md:px-35 md:py-8">
-        내가 쓴 글
-      </div>
-      <div className="rounded-md bg-white px-23 py-4 text-black md:px-35 md:py-8">
-        내가 쓴 댓글
-      </div>
-      <div className="rounded-md bg-white px-23 py-4 text-black md:px-35 md:py-8">
-        스크랩
-      </div>
+      {tabs.map((label, idx) => (
+        <button
+          key={label}
+          className={`rounded-md px-23 py-4 md:px-35 md:py-8 ${activeTab === idx ? 'bg-white text-black' : 'bg-white text-gray-400'}`}
+          onClick={() => setActiveTab(idx)}
+        >
+          {label}
+        </button>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.
- 헤더 반응형 세부 조정
- 헤더 및 사이드 바 border-bottom 색상 조정
- 탭 버튼 UI 구현
---

## 🧩 관련 이슈
- Close #28 

---

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/3720aace-527c-4b7e-9f9d-2c4e69213461


---

## 💬 참고 사항
- 헤더 및 탭 버튼의 경우 반응형 구현 최종으로 끝났고 피그마 상으로 UI가 모바일 화면으로 share 기능이 들어가 있는 부분은 포함되어있는 페이지가 없어서 미구현 상태입니다.
- 모바일 화면에서는 로그인 전 헤더 쪽의 **사장님 전용, 알바생 전용** 문구가 하단 중앙에 배치되어야하는데, 회원가입 후 지원자 정보 페이지로 가게 되면 사라져야 하는 부분까지 일단 구현해두었습니다!(`MobileNav.tsx`로 따로 작성하여 상황에 따라 불러오도록 설정)
---
