### PR TITLE
[fix] next.config.js 및 metadata의 themeColor의 적용 방법 변경

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,14 +1,12 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  experimental: {
-    turbo: {
-      rules: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        '*.svg': {
-          loaders: ['@svgr/webpack'],
-          as: '*.js',
-        },
+  turbopack: {
+    rules: {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      '*.svg': {
+        loaders: ['@svgr/webpack'],
+        as: '*.js',
       },
     },
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Providers } from '@/app/providers';
 import ModalManager from '@/shared/components/common/modal/ModalManager';
 
 import { metadata } from './metadata';
+import { viewport } from './viewport';
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -17,6 +18,7 @@ const pretendard = localFont({
 
 // eslint-disable-next-line react-refresh/only-export-components
 export { metadata };
+export { viewport };
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -5,5 +5,4 @@ export const metadata: Metadata = {
   description: 'Albamate application', // 추후 변경 가능
   authors: [{ name: 'Albamate Team' }],
   keywords: ['알바', '채용', '구인', '구직', 'Albamate'],
-  themeColor: '#ffffff',
 };

--- a/src/app/viewport.ts
+++ b/src/app/viewport.ts
@@ -1,0 +1,5 @@
+import type { Viewport } from 'next';
+
+export const viewport: Viewport = {
+  themeColor: '#ffffff',
+};


### PR DESCRIPTION
## 📝 PR 내용 요약

- next.config.js의 experimental을 turbopack으로 변경
- metadata의 themeColor 적용 방법을 viewport로 변경

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #61 

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---

## 💬 참고 사항

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * `viewport` 설정이 추가되어 별도로 내보내집니다.

* **변경 사항**
  * `themeColor` 속성이 메타데이터에서 분리되어 `viewport`로 이동되었습니다.
  * 내부 설정 구조가 단순화되어 SVG 파일 처리가 유지되면서 설정 위치가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->