### PR TITLE
[feat] useClickOutside 훅 구현 (외부 클릭 시 닫기 기능)

### DIFF
--- a/.coderabbit/config.yml
+++ b/.coderabbit/config.yml
@@ -5,5 +5,3 @@ review:
     - pattern: '**/*'
       approve: true
       comment: true
-      conditions:
-        - '!has_merge_conflict'

--- a/.github/workflows/add-coderabbit.yml
+++ b/.github/workflows/add-coderabbit.yml
@@ -1,0 +1,20 @@
+name: Auto add CodeRabbit as reviewer
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add CodeRabbit as reviewer
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers: ['coderabbitai']
+            })

--- a/src/app/test/sumin/page.tsx
+++ b/src/app/test/sumin/page.tsx
@@ -6,10 +6,6 @@ import InputDropdown from '@common/input-dropdown';
 import TimePicker from '@common/time-picker';
 import WeekPicker from '@common/week-picker';
 
-import DatePicker from '@/shared/components/common/date-picker';
-import InputDropdown from '@/shared/components/common/input-dropdown';
-import TimePicker from '@/shared/components/common/time-picker';
-import WeekPicker from '@/shared/components/common/week-picker';
 import InnerContainer from '@/shared/components/container/InnerContainer';
 import CopyAddress from '@/shared/components/ui/CopyAddress';
 import KakaoMap from '@/shared/components/ui/KakaoMap';

--- a/src/app/test/yujin/page.tsx
+++ b/src/app/test/yujin/page.tsx
@@ -9,6 +9,9 @@ import Tooltip from '@common/tooltip/Tooltip';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 
+import DatePicker from '@/shared/components/common/date-picker';
+import Dropdown from '@/shared/components/ui/Dropdown';
+
 const TestPage = () => {
   const [popupVisible, setPopupVisible] = useState(false);
 
@@ -139,6 +142,27 @@ const TestPage = () => {
       </div>
 
       <div className="bg-red">red</div>
+
+      <Dropdown
+        className="w-48"
+        id="example-menu"
+        trigger={
+          <button
+            className="w-full rounded bg-blue-500 px-4 py-2 text-white"
+            type="button"
+          >
+            메뉴 열기
+          </button>
+        }
+      >
+        <ul className="flex flex-col gap-2 p-4">
+          <li className="cursor-pointer hover:text-blue-500">옵션 1</li>
+          <li className="cursor-pointer hover:text-blue-500">옵션 2</li>
+          <li className="cursor-pointer hover:text-blue-500">옵션 3</li>
+        </ul>
+      </Dropdown>
+
+      <DatePicker />
     </div>
   );
 };

--- a/src/shared/components/common/date-picker/index.tsx
+++ b/src/shared/components/common/date-picker/index.tsx
@@ -6,9 +6,11 @@ import '@/app/day-picker-override.css'; // react day picker 커스텀 오버라�
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { DateRange, DayPicker } from 'react-day-picker';
 import { twMerge } from 'tailwind-merge';
+
+import { useClickOutside } from '@/shared/hooks/useClickOutside';
 
 /**
  * DatePicker 컴포넌트
@@ -52,18 +54,9 @@ const DatePicker = ({
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   // 외부 클릭 시 닫기
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useClickOutside(containerRef, () => {
+    setIsOpen(false);
+  });
 
   // 키보드 이벤트 처리
   const handleKeyDown = (event: React.KeyboardEvent) => {

--- a/src/shared/components/common/input/Input.tsx
+++ b/src/shared/components/common/input/Input.tsx
@@ -1,11 +1,6 @@
 import { inputStyle, inputVariants } from '@common/input/inputStyles';
 import { DetailedHTMLProps, InputHTMLAttributes } from 'react';
 
-
-import {
-  inputStyle,
-  inputVariants,
-} from '@/shared/components/common/input/inputStyles';
 import { cn } from '@/shared/lib/cn';
 
 export interface InputProps

--- a/src/shared/components/common/input/Textarea.tsx
+++ b/src/shared/components/common/input/Textarea.tsx
@@ -1,10 +1,6 @@
 import { inputStyle, inputVariants } from '@common/input/inputStyles';
 import { DetailedHTMLProps, TextareaHTMLAttributes } from 'react';
 
-import {
-  inputStyle,
-  inputVariants,
-} from '@/shared/components/common/input/inputStyles';
 import { cn } from '@/shared/lib/cn';
 
 interface TextareaProps

--- a/src/shared/components/ui/Dropdown.tsx
+++ b/src/shared/components/ui/Dropdown.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
+import { useClickOutside } from '@/shared/hooks/useClickOutside';
+
 /**
  * Dropdown 컴포넌트
  *
@@ -29,7 +31,6 @@ import { twMerge } from 'tailwind-merge';
  *   </ul>
  * </Dropdown>
  */
-
 interface DropdownProps {
   trigger: React.ReactNode | ((isOpen: boolean) => React.ReactNode);
   children: React.ReactNode;
@@ -46,7 +47,7 @@ const Dropdown = ({
   isRight = false,
 }: DropdownProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null); // 드롭다운 영역 감지용 ref
 
   const renderTrigger = () => {
     if (typeof trigger === 'function') {
@@ -56,24 +57,7 @@ const Dropdown = ({
   };
 
   // 외부 클릭 시 드롭다운 닫기
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
-      ) {
-        setIsOpen(false);
-      }
-    };
-
-    // 이벤트 리스너 등록
-    document.addEventListener('mousedown', handleClickOutside);
-
-    // 클린업 함수
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
+  useClickOutside(dropdownRef, () => setIsOpen(false));
 
   // ESC 키로 드롭다운 닫기
   useEffect(() => {
@@ -97,7 +81,7 @@ const Dropdown = ({
   return (
     <div
       ref={dropdownRef}
-      className={`relative ${className}`}
+      className={twMerge('relative', className)}
       data-dropdown-id={id} // 고유 식별자
     >
       <div

--- a/src/shared/hooks/useClickOutside.ts
+++ b/src/shared/hooks/useClickOutside.ts
@@ -1,0 +1,28 @@
+// shared/hooks/useClickOutside.ts
+import { RefObject, useEffect } from 'react';
+
+/**
+ * 외부 클릭 시 핸들러 실행 훅
+ *
+ * @param ref - 감지할 DOM 요소의 ref
+ * @param handler - 외부 클릭 시 실행할 함수
+ */
+export function useClickOutside<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  handler: (event: MouseEvent | TouchEvent) => void
+) {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) return;
+      handler(event);
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}


### PR DESCRIPTION
## 📝 PR 내용 요약

✨Feat: 외부 클릭 시 닫기 기능 훅 구현
🐛Fix: import 중복 선언 삭제

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #80 

---

## 📸 스크린샷 (선택)

https://github.com/user-attachments/assets/476adc33-53b5-4abc-ac82-82ce8d8570ff

---

## 💬 참고 사항
- import 중복 선언 문제 부분 수정해서 같이 올렸습니다!
- 사용되는 부분에서 `useClickOutside` 훅 가져다 쓰시면 될 것 같습니다!
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 새로운 드롭다운 및 날짜 선택 UI 컴포넌트가 추가되었습니다.
  * 외부 클릭 시 닫힘 처리를 위한 커스텀 훅이 도입되었습니다.

* **Refactor**
  * 드롭다운과 날짜 선택기에서 외부 클릭 감지 로직이 커스텀 훅으로 대체되어 코드가 간결해졌습니다.
  * 중복된 import 구문이 정리되어 코드가 더 깔끔해졌습니다.

* **Chores**
  * GitHub Actions 워크플로우가 추가되어 자동으로 리뷰어가 지정됩니다.
  * 리뷰 규칙 설정이 간소화되어 모든 파일에 자동 승인 및 코멘트가 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->