### PR TITLE
[feat] 알바토크 목록 페이지 구현

### DIFF
--- a/src/app/(public)/albatalk/layout.tsx
+++ b/src/app/(public)/albatalk/layout.tsx
@@ -1,9 +1,0 @@
-const AboutLayout = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <div>
-      <main>{children}</main>
-    </div>
-  );
-};
-
-export default AboutLayout;

--- a/src/app/(public)/albatalk/page.tsx
+++ b/src/app/(public)/albatalk/page.tsx
@@ -1,12 +1,11 @@
-import MainGnb from '@common/gnb/main-gnb';
+import PostList from '@/features/albatalk/components/post-list';
+import InnerContainer from '@/shared/components/container/InnerContainer';
 
 const AlbaTalkPage = () => {
   return (
-    <div>
-      <MainGnb />
-      {/* 콘텐츠 영역 */}
-      <div>알바토크</div>
-    </div>
+    <InnerContainer>
+      <PostList />
+    </InnerContainer>
   );
 };
 

--- a/src/features/albatalk/components/post-item/PostCardHeader.tsx
+++ b/src/features/albatalk/components/post-item/PostCardHeader.tsx
@@ -1,0 +1,69 @@
+'use client';
+import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
+
+import AlbaDropdown from '@/features/albalist/components/AlbaDropdown';
+
+interface PostHeaderProps {
+  title: string;
+  postId: number;
+}
+
+const PostCardHeader = ({ title, postId }: PostHeaderProps) => {
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  const handleActionClick = (option: string) => {
+    if (option === 'edit') {
+      console.log('수정하기:', postId);
+      // 수정 로직
+    } else if (option === 'delete') {
+      console.log('삭제하기:', postId);
+      // 삭제 로직
+    }
+    setOpen(false); // 클릭 후 드롭다운 닫기
+  };
+
+  const menuOptions = [
+    { label: '수정하기', onClick: () => handleActionClick('edit') },
+    { label: '삭제하기', onClick: () => handleActionClick('delete') },
+  ];
+
+  return (
+    <div className="mb-8 flex items-start justify-between">
+      <h2 className="mr-12 line-clamp-2 flex-1 text-lg font-semibold break-words text-gray-900 dark:text-white">
+        {title}
+      </h2>
+      <div ref={dropdownRef} className="relative ml-auto">
+        <Image
+          alt="드롭다운 아이콘"
+          className="cursor-pointer"
+          height={24}
+          src="/icons/kebab-menu.svg"
+          width={24}
+          onClick={e => {
+            e.stopPropagation();
+            setOpen(prev => !prev);
+          }}
+        />
+        {open && <AlbaDropdown options={menuOptions} />}
+      </div>
+    </div>
+  );
+};
+
+export default PostCardHeader;

--- a/src/features/albatalk/components/post-item/PostCardHeader.tsx
+++ b/src/features/albatalk/components/post-item/PostCardHeader.tsx
@@ -29,11 +29,10 @@ const PostCardHeader = ({ title, postId }: PostHeaderProps) => {
 
   const handleActionClick = (option: string) => {
     if (option === 'edit') {
-      console.log('수정하기:', postId);
-      // 수정 로직
+      //TODO: 수정 로직
+      alert(postId);
     } else if (option === 'delete') {
-      console.log('삭제하기:', postId);
-      // 삭제 로직
+      //TODO: 삭제 로직
     }
     setOpen(false); // 클릭 후 드롭다운 닫기
   };
@@ -53,6 +52,7 @@ const PostCardHeader = ({ title, postId }: PostHeaderProps) => {
           alt="드롭다운 아이콘"
           className="cursor-pointer"
           height={24}
+          role="button"
           src="/icons/kebab-menu.svg"
           width={24}
           onClick={e => {

--- a/src/features/albatalk/components/post-item/PostCardHeader.tsx
+++ b/src/features/albatalk/components/post-item/PostCardHeader.tsx
@@ -54,10 +54,18 @@ const PostCardHeader = ({ title, postId }: PostHeaderProps) => {
           height={24}
           role="button"
           src="/icons/kebab-menu.svg"
+          tabIndex={0}
           width={24}
           onClick={e => {
             e.stopPropagation();
             setOpen(prev => !prev);
+          }}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              e.stopPropagation();
+              setOpen(prev => !prev);
+            }
           }}
         />
         {open && <AlbaDropdown options={menuOptions} />}

--- a/src/features/albatalk/components/post-item/PostMetaInfo.tsx
+++ b/src/features/albatalk/components/post-item/PostMetaInfo.tsx
@@ -1,0 +1,90 @@
+import Image from 'next/image';
+import React, { useState } from 'react';
+
+import Profile from '@/shared/components/common/profile/Profile';
+import { cn } from '@/shared/lib/cn';
+import { formatDate } from '@/shared/utils/date';
+
+import { Writer } from '../../types/albatalk';
+
+interface PostMetaInfoProps {
+  writer: Writer;
+  createdAt: string;
+  commentCount: number;
+  initialLikeCount: number;
+  postId: number;
+  className?: string;
+}
+
+const PostMetaInfo = ({
+  writer,
+  createdAt,
+  commentCount,
+  initialLikeCount,
+  postId,
+  className,
+}: PostMetaInfoProps) => {
+  const [isLiked, setIsLiked] = useState(false);
+  const [likeCount, setLikeCount] = useState(initialLikeCount);
+  const likeIconSrc = isLiked ? '/icons/like-active.svg' : '/icons/like.svg';
+
+  const handleLikeToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    setIsLiked(prev => !prev);
+    setLikeCount(prev => (isLiked ? prev - 1 : prev + 1));
+    console.log(`좋아요 ${isLiked ? '취소' : '추가'} : ${postId}`);
+  };
+
+  return (
+    <div
+      className={cn('flex justify-between text-xs text-gray-500', className)}
+    >
+      <div className="flex items-center gap-7">
+        {/* 프로필 이미지 */}
+        <div className="size-24">
+          {writer.imageUrl ? (
+            <Profile
+              className="size-26 border-none lg:size-26"
+              imageUrl={writer.imageUrl}
+            />
+          ) : (
+            <Profile className="size-26 border-none lg:size-26" sizes="26px" />
+          )}
+        </div>
+        {/* 닉네임 */}
+        <span>{writer.nickname}</span>
+        <div className="h-12 w-px bg-line-200" />
+        {/* 날짜 */}
+        <time>{formatDate(createdAt, 'post')}</time>
+      </div>
+
+      <div className="flex gap-12">
+        {/* 댓글 수 */}
+        <div className="flex">
+          <Image
+            alt="comment_count"
+            height={24}
+            src="/icons/comment.svg"
+            width={24}
+          />
+          <span className="ml-2 self-center">{commentCount}</span>
+        </div>
+
+        {/* 좋아요 */}
+        <div className="flex" onClick={handleLikeToggle}>
+          <button
+            aria-label="좋아요 버튼"
+            className="transition-transform duration-150 hover:scale-110 active:scale-95"
+            type="button"
+          >
+            <Image alt="like_icon" height={24} src={likeIconSrc} width={24} />
+          </button>
+          <span className="ml-2 min-w-24 self-center">{likeCount}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostMetaInfo;

--- a/src/features/albatalk/components/post-item/PostMetaInfo.tsx
+++ b/src/features/albatalk/components/post-item/PostMetaInfo.tsx
@@ -30,9 +30,12 @@ const PostMetaInfo = ({
   const handleLikeToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
 
-    setIsLiked(prev => !prev);
-    setLikeCount(prev => (isLiked ? prev - 1 : prev + 1));
-    console.log(`좋아요 ${isLiked ? '취소' : '추가'} : ${postId}`);
+    setIsLiked(prev => {
+      const newIsLiked = !prev;
+      setLikeCount(prevCount => (prev ? prevCount - 1 : prevCount + 1));
+      console.log(`좋아요 ${prev ? '취소' : '추가'} : ${postId}`);
+      return newIsLiked;
+    });
   };
 
   return (
@@ -41,7 +44,7 @@ const PostMetaInfo = ({
     >
       <div className="flex items-center gap-7">
         {/* 프로필 이미지 */}
-        <div className="size-24">
+        <div className="size-26">
           {writer.imageUrl ? (
             <Profile
               className="size-26 border-none lg:size-26"

--- a/src/features/albatalk/components/post-item/PostMetaInfo.tsx
+++ b/src/features/albatalk/components/post-item/PostMetaInfo.tsx
@@ -1,11 +1,10 @@
 import Image from 'next/image';
 import React, { useState } from 'react';
 
+import { Writer } from '@/features/albatalk/types/albatalk';
 import Profile from '@/shared/components/common/profile/Profile';
 import { cn } from '@/shared/lib/cn';
 import { formatDate } from '@/shared/utils/date';
-
-import { Writer } from '../../types/albatalk';
 
 interface PostMetaInfoProps {
   writer: Writer;

--- a/src/features/albatalk/components/post-item/index.tsx
+++ b/src/features/albatalk/components/post-item/index.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { Post } from '@/features/albatalk/types/albatalk';
+
+import PostCardHeader from './PostCardHeader';
+import PostFooter from './PostMetaInfo';
+
+interface PostItemProps {
+  post: Post;
+}
+
+const PostItem = ({ post }: PostItemProps) => {
+  const router = useRouter();
+
+  const handlePostClick = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    const isInteractiveElement =
+      target.closest('button') ||
+      target.closest('[role="button"]') ||
+      target.closest('[role="menu"]');
+
+    if (isInteractiveElement) {
+      return;
+    }
+
+    router.push(`/post/${post.id}`);
+  };
+
+  return (
+    <div
+      className="Border-Card flex h-210 w-full min-w-0 flex-1 cursor-pointer flex-col gap-24 rounded-xl p-24 transition-all duration-300 hover:scale-[1.01] hover:shadow-lg"
+      onClick={handlePostClick}
+    >
+      <div className="min-w-0 flex-1">
+        <PostCardHeader postId={post.id} title={post.title} />
+        <p className="line-clamp-2 w-220 text-gray-500 dark:text-gray-300">
+          {post.content}
+        </p>
+      </div>
+      <PostFooter
+        commentCount={post.commentCount}
+        createdAt={post.createdAt}
+        initialLikeCount={post.likeCount}
+        postId={post.id}
+        writer={post.writer}
+      />
+    </div>
+  );
+};
+
+export default PostItem;

--- a/src/features/albatalk/components/post-list/PostFilterBar.tsx
+++ b/src/features/albatalk/components/post-list/PostFilterBar.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import IconInput from '@common/input/IconInput';
+import { useState } from 'react';
+
+import Select from '@/shared/components/common/select';
+
+const PostFilterBar = () => {
+  const [searchQuery, setSearchQuery] = useState<string>('');
+
+  const sortOptions = [
+    { value: 'mostRecent', label: '최신순' },
+    { value: 'mostCommented', label: '댓글많은순' },
+    { value: 'mostLiked', label: '좋아요순' },
+  ];
+
+  const handleSearchSubmit = () => {
+    if (searchQuery.trim()) {
+      alert(searchQuery.trim());
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearchSubmit();
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value);
+  };
+
+  const handleSortChange = (value: string) => alert(value);
+
+  return (
+    <div className="flex flex-col px-4 py-16 lg:flex-row lg:justify-between">
+      <IconInput
+        alt="검색"
+        className="my-16 lg:my-24 lg:w-728"
+        iconClassName="pl-24"
+        iconOnClick={handleSearchSubmit}
+        inputClassName="rounded-2xl lg:rounded-3xl lg:pl-68"
+        placeholder="궁금한 점을 검색해보세요"
+        src="/icons/search.svg"
+        value={searchQuery}
+        onChange={handleInputChange}
+        onKeyDown={handleKeyDown}
+      />
+      <div className="justify-items-end lg:self-center">
+        <Select
+          className="mt-8"
+          options={sortOptions}
+          variant="sort"
+          onSelect={handleSortChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default PostFilterBar;

--- a/src/features/albatalk/components/post-list/index.tsx
+++ b/src/features/albatalk/components/post-list/index.tsx
@@ -1,0 +1,50 @@
+'use client';
+import FloatingButtonContainer from '@common/button/FloatingButtonContainer';
+import { useEffect, useState } from 'react';
+
+import Loading from '@/app/loading';
+import mockPostsData from '@/features/albatalk/mocks/getPosts';
+import { Post } from '@/features/albatalk/types/albatalk';
+import FloatingButton from '@/shared/components/common/button/FloatingButton';
+
+import PostItem from '../post-item/index';
+import PostFilterBar from './PostFilterBar';
+
+const PostList: React.FC = () => {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      try {
+        setPosts(mockPostsData.data);
+        setLoading(false);
+      } catch (err) {
+        console.error(err);
+        setLoading(false);
+      }
+    }, 500); // 0.5초 딜레이
+  }, []);
+
+  if (loading) {
+    return <Loading />;
+  }
+
+  return (
+    <div className="mx-auto max-w-1480 pb-128">
+      <div className="flex flex-col gap-30">
+        <PostFilterBar />
+        <section className="grid grid-cols-1 gap-16 lg:grid-cols-3">
+          {posts.map(post => (
+            <PostItem key={post.id} post={post} />
+          ))}
+        </section>
+        <FloatingButtonContainer>
+          <FloatingButton href="/albatalk/" type="addAlbatalk" />
+        </FloatingButtonContainer>
+      </div>
+    </div>
+  );
+};
+
+export default PostList;

--- a/src/features/albatalk/mocks/getPosts.ts
+++ b/src/features/albatalk/mocks/getPosts.ts
@@ -1,0 +1,104 @@
+import { PostsResponse } from '@/features/albatalk/types/albatalk';
+
+const mockPostsData: PostsResponse = {
+  data: [
+    {
+      id: 370,
+      title: 'ㅂㅈㄷㄱ',
+      content: 'ㅂㅈㄷㄱ',
+      imageUrl:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Albaform/user/414/1752617866179/coplan.png',
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: '2025-07-15T22:17:48.422Z',
+      updatedAt: '2025-07-15T22:17:48.422Z',
+      writer: {
+        id: 414,
+        nickname: '초지동얼음공주',
+        imageUrl: null,
+      },
+    },
+    {
+      id: 231,
+      title: '테스트',
+      content: '테스트입니다.',
+      imageUrl: '',
+      likeCount: 0,
+      commentCount: 2,
+      createdAt: '2024-12-28T06:48:18.678Z',
+      updatedAt: '2025-07-15T22:16:31.662Z',
+      writer: {
+        id: 193,
+        nickname: '전상민',
+        imageUrl: '',
+      },
+    },
+    {
+      id: 221,
+      title: '내년 크리스마스는',
+      content: '제~~~~~~~발',
+      imageUrl: '',
+      likeCount: 1,
+      commentCount: 5,
+      createdAt: '2024-12-25T06:29:46.248Z',
+      updatedAt: '2024-12-26T19:33:39.762Z',
+      writer: {
+        id: 193,
+        nickname: '전상민',
+        imageUrl: null,
+      },
+    },
+    {
+      id: 220,
+      title: '캐캐싱싱테테스트',
+      content: 'ㅋㅅㅌㅅㅌ',
+      imageUrl:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Albaform/user/193/1735108004862/screencapture-localhost-3000-mypage-2024-12-23-12_58_12.png',
+      likeCount: 0,
+      commentCount: 1,
+      createdAt: '2024-12-25T06:26:46.329Z',
+      updatedAt: '2024-12-26T23:53:11.237Z',
+      writer: {
+        id: 193,
+        nickname: '전상민',
+        imageUrl: null,
+      },
+    },
+    {
+      id: 219,
+      title: '캐싱 테스트',
+      content: '태그 캐싱',
+      imageUrl:
+        'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Albaform/user/193/1735107937845/screencapture-localhost-3000-albatalk-2024-12-25-03_22_59.png',
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: '2024-12-25T06:25:39.802Z',
+      updatedAt: '2024-12-25T06:25:39.802Z',
+      writer: {
+        id: 193,
+        nickname: '전상민',
+        imageUrl:
+          'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Albaform/user/190/1732608458993/profile.png',
+      },
+    },
+    {
+      id: 218,
+      title: '메리스크리마스욧',
+      content: '후 크리스마스라니',
+      imageUrl: '',
+      likeCount: 0,
+      commentCount: 0,
+      createdAt: '2024-12-25T06:04:23.104Z',
+      updatedAt: '2024-12-25T06:04:23.104Z',
+      writer: {
+        id: 193,
+        nickname: '전상민',
+        imageUrl:
+          'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Albaform/user/246/1735158934022/screencapture-localhost-3000-albatalk-2024-12-25-03_22_59.png',
+      },
+    },
+  ],
+  nextCursor: 218,
+};
+
+export default mockPostsData;

--- a/src/features/albatalk/types/albatalk.ts
+++ b/src/features/albatalk/types/albatalk.ts
@@ -1,0 +1,29 @@
+export interface Writer {
+  id: number;
+  nickname: string;
+  imageUrl: string | null;
+}
+
+export interface Post {
+  id: number;
+  title: string;
+  content: string;
+  imageUrl: string;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string;
+  updatedAt: string;
+  writer: Writer;
+}
+
+export interface PostsResponse {
+  data: Post[];
+  nextCursor: number | null;
+}
+
+export interface GetPostsParams {
+  limit: number;
+  cursor?: number;
+  orderBy?: 'mostRecent' | 'mostCommented' | 'mostLiked';
+  keyword?: string;
+}

--- a/src/features/albatalk/types/albatalk.ts
+++ b/src/features/albatalk/types/albatalk.ts
@@ -8,7 +8,7 @@ export interface Post {
   id: number;
   title: string;
   content: string;
-  imageUrl: string;
+  imageUrl: string | null;
   likeCount: number;
   commentCount: number;
   createdAt: string;

--- a/src/shared/components/container/InnerContainer.tsx
+++ b/src/shared/components/container/InnerContainer.tsx
@@ -21,6 +21,7 @@ import { cn } from '@/shared/lib/cn';
 interface InnerContainerProps {
   children: ReactNode;
   size?: 'sm' | 'md' | 'lg' | 'xl';
+  tabletSize?: 'sm' | 'md' | 'lg';
   className?: string;
   isFlex?: boolean;
 }
@@ -28,6 +29,7 @@ interface InnerContainerProps {
 const InnerContainer = ({
   children,
   size = 'md',
+  tabletSize = 'md',
   className,
   isFlex,
 }: InnerContainerProps) => {
@@ -36,6 +38,12 @@ const InnerContainer = ({
       className={cn(
         'mx-auto max-w-375 px-24',
         // 패딩(padding) 24px * 2 = 48px을 더한 max-w값
+
+        // 태블릿 브레이크포인트 (md)
+        tabletSize === 'sm' && 'md:max-w-568', // 520px + 48px
+        tabletSize === 'md' && 'md:max-w-648', // 600px + 48px
+        tabletSize === 'lg' && 'md:max-w-768', // 720px + 48px
+
         size === 'sm' && 'lg:max-w-688',
         size === 'md' && 'lg:max-w-1528',
         size === 'lg' && 'lg:max-w-1608',

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -1,0 +1,121 @@
+/**
+ * 상대적 시간 포맷팅 (오늘, 어제, n일 전)
+ */
+export const formatRelativeTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffTime = Math.abs(now.getTime() - date.getTime());
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 1) {
+    return '오늘';
+  } else if (diffDays === 2) {
+    return '어제';
+  } else if (diffDays <= 7) {
+    return `${diffDays - 1}일 전`;
+  } else if (diffDays <= 30) {
+    const weeks = Math.floor((diffDays - 1) / 7);
+    return `${weeks}주 전`;
+  } else if (diffDays <= 365) {
+    const months = Math.floor((diffDays - 1) / 30);
+    return `${months}개월 전`;
+  } else {
+    const years = Math.floor((diffDays - 1) / 365);
+    return `${years}년 전`;
+  }
+};
+
+/**
+ * 절대적 날짜 포맷팅 (YYYY.MM.DD)
+ */
+export const formatAbsoluteDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  return date
+    .toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replace(/\. /g, '.')
+    .replace(/\.$/, '');
+};
+
+/**
+ * 시간 포함 포맷팅 (YYYY.MM.DD HH:mm)
+ */
+export const formatDateTime = (dateString: string): string => {
+  const date = new Date(dateString);
+  const dateStr = formatAbsoluteDate(dateString);
+  const timeStr = date.toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+  return `${dateStr} ${timeStr}`;
+};
+
+/**
+ * 한국어 날짜 포맷팅 (YYYY MM월 DD일)
+ */
+export const formatKoreanDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+};
+
+/**
+ * 게시글 목록용 포맷팅 (상대적 시간 우선, 오래된 건 절대 날짜)
+ */
+export const formatPostDate = (dateString: string): string => {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffTime = Math.abs(now.getTime() - date.getTime());
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  // 7일 이내는 상대적 시간
+  if (diffDays <= 7) {
+    return formatRelativeTime(dateString);
+  }
+
+  // 7일 이후는 절대 날짜
+  return formatAbsoluteDate(dateString);
+};
+
+// 타입 정의
+export type DateFormatType =
+  | 'relative' // 상대적 시간 (오늘, 어제, n일 전)
+  | 'absolute' // 절대 날짜 (2024.12.28)
+  | 'korean' // 한국어 날짜 (2024년 12월 28일)
+  | 'datetime' // 날짜 + 시간 (2024.12.28 14:30)
+  | 'post'; // 게시글용 (혼합)
+
+/**
+ * 통합 날짜 포맷팅 함수
+ *
+ * @example
+ * ```tsx
+ * {formatDate(post.createdAt, 'post')}
+ * ```
+ */
+export const formatDate = (
+  dateString: string,
+  type: DateFormatType = 'relative'
+): string => {
+  switch (type) {
+    case 'relative':
+      return formatRelativeTime(dateString);
+    case 'absolute':
+      return formatAbsoluteDate(dateString);
+    case 'korean':
+      return formatKoreanDate(dateString);
+    case 'datetime':
+      return formatDateTime(dateString);
+    case 'post':
+      return formatPostDate(dateString);
+    default:
+      return formatRelativeTime(dateString);
+  }
+};

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -1,26 +1,42 @@
 /**
+ * 날짜 간 일수 차이 계산 (시간 제외, 날짜만 비교)
+ */
+const getDaysDifference = (dateString: string): number => {
+  const date = new Date(dateString);
+  const now = new Date();
+
+  // 시간 부분 제거하고 날짜만 비교
+  const dateOnly = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate()
+  );
+  const nowOnly = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  const diffTime = nowOnly.getTime() - dateOnly.getTime();
+  return Math.floor(diffTime / (1000 * 60 * 60 * 24));
+};
+
+/**
  * 상대적 시간 포맷팅 (오늘, 어제, n일 전)
  */
 export const formatRelativeTime = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffTime = Math.abs(now.getTime() - date.getTime());
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const diffDays = getDaysDifference(dateString);
 
-  if (diffDays === 1) {
+  if (diffDays === 0) {
     return '오늘';
-  } else if (diffDays === 2) {
+  } else if (diffDays === 1) {
     return '어제';
   } else if (diffDays <= 7) {
-    return `${diffDays - 1}일 전`;
+    return `${diffDays}일 전`;
   } else if (diffDays <= 30) {
-    const weeks = Math.floor((diffDays - 1) / 7);
+    const weeks = Math.floor(diffDays / 7);
     return `${weeks}주 전`;
   } else if (diffDays <= 365) {
-    const months = Math.floor((diffDays - 1) / 30);
+    const months = Math.floor(diffDays / 30);
     return `${months}개월 전`;
   } else {
-    const years = Math.floor((diffDays - 1) / 365);
+    const years = Math.floor(diffDays / 365);
     return `${years}년 전`;
   }
 };
@@ -70,10 +86,7 @@ export const formatKoreanDate = (dateString: string): string => {
  * 게시글 목록용 포맷팅 (상대적 시간 우선, 오래된 건 절대 날짜)
  */
 export const formatPostDate = (dateString: string): string => {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffTime = Math.abs(now.getTime() - date.getTime());
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const diffDays = getDaysDifference(dateString);
 
   // 7일 이내는 상대적 시간
   if (diffDays <= 7) {


### PR DESCRIPTION
## 📝 PR 내용 요약

- 알바토크 목록 리스트 구현
- 날짜 포맷 유틸함수 추가

---

## 🧩 관련 이슈

- Close #59 

---

## 📸 스크린샷 (선택)

![화면 기록 2025-07-18 오전 5 09 26](https://github.com/user-attachments/assets/6553fcd5-41ab-498d-8f87-41f764ba5162)

---

## 💬 참고 사항

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게시글 목록, 필터바, 게시글 카드, 게시글 메타 정보, 게시글 헤더 등 알바톡 게시판 주요 컴포넌트가 추가되었습니다.
  * 게시글 목록에 대한 검색 및 정렬 기능이 도입되었습니다.
  * 게시글 목록, 작성자 정보, 댓글/좋아요 수, 날짜 등 다양한 정보를 표시합니다.
  * 게시글 데이터 및 타입, 날짜 포맷 유틸리티가 추가되었습니다.
  * 반응형 내비게이션 컨테이너 크기 조절 기능이 도입되었습니다.

* **버그 수정**
  * 불필요한 레이아웃 컴포넌트가 제거되어 페이지 구조가 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->