### PR TITLE
[feat] 알바토크 상세 페이지 구현

### DIFF
--- a/public/icons/empty-list.svg
+++ b/public/icons/empty-list.svg
@@ -1,0 +1,159 @@
+<svg width="121" height="120" viewBox="0 0 121 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="60" cy="60" r="60" fill="url(#paint0_linear_993_10651)"/>
+<g filter="url(#filter0_di_993_10651)">
+<path d="M50.5 21C53.2958 21 55.6455 22.9121 56.3115 25.5H61C64.3137 25.5 67 28.1863 67 31.5V34.5C67 36.1569 65.6569 37.5 64 37.5H37C35.3431 37.5 34 36.1569 34 34.5V31.5C34 28.1863 36.6863 25.5 40 25.5H44.6885C45.3545 22.9121 47.7042 21 50.5 21Z" fill="#D9D9D9"/>
+</g>
+<foreignObject x="16" y="24" width="69" height="81"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(3px);clip-path:url(#bgblur_0_993_10651_clip_path);height:100%;width:100%"></div></foreignObject><rect data-figma-bg-blur-radius="6" x="22" y="30" width="57" height="69" rx="6" fill="url(#paint1_linear_993_10651)" fill-opacity="0.5"/>
+<foreignObject x="49.0234" y="35.125" width="71.4102" height="71.4062"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(1.5px);clip-path:url(#bgblur_1_993_10651_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter2_di_993_10651)" data-figma-bg-blur-radius="3">
+<path d="M101.993 58.3606C102.579 58.9464 102.579 59.8961 101.993 60.4819L75.6634 86.812C75.1563 87.3191 74.4843 87.6284 73.7692 87.6828L62.6364 88.5266C61.7205 88.5961 60.958 87.8336 61.0275 86.9176L61.872 75.7855C61.9263 75.0704 62.2349 74.3979 62.7421 73.8907L79.7955 56.8373L92.7161 69.7579L95.3008 67.1732L82.3802 54.2526L89.0722 47.5607C89.6579 46.9749 90.6077 46.9749 91.1935 47.5607L101.993 58.3606Z" fill="url(#paint2_linear_993_10651)" fill-opacity="0.8" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="14.5" y="25.5" width="84" height="51"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(3px);clip-path:url(#bgblur_2_993_10651_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter3_di_993_10651)" data-figma-bg-blur-radius="6">
+<rect x="32.5" y="43.5" width="36" height="3" rx="1.5" fill="url(#paint3_linear_993_10651)" fill-opacity="0.5" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="14.5" y="36" width="84" height="51"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(3px);clip-path:url(#bgblur_3_993_10651_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter4_di_993_10651)" data-figma-bg-blur-radius="6">
+<rect x="32.5" y="54" width="36" height="3" rx="1.5" fill="url(#paint4_linear_993_10651)" fill-opacity="0.5" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="14.5" y="46.5" width="72" height="51"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(3px);clip-path:url(#bgblur_4_993_10651_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter5_di_993_10651)" data-figma-bg-blur-radius="6">
+<rect x="32.5" y="64.5" width="24" height="3" rx="1.5" fill="url(#paint5_linear_993_10651)" fill-opacity="0.5" shape-rendering="crispEdges"/>
+</g>
+<foreignObject x="14.5" y="57" width="63" height="51"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(3px);clip-path:url(#bgblur_5_993_10651_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter6_di_993_10651)" data-figma-bg-blur-radius="6">
+<rect x="32.5" y="75" width="15" height="3" rx="1.5" fill="url(#paint6_linear_993_10651)" fill-opacity="0.5" shape-rendering="crispEdges"/>
+</g>
+<defs>
+<filter id="filter0_di_993_10651" x="25" y="18" width="51" height="37.5" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="9"/>
+<feGaussianBlur stdDeviation="4.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.956863 0 0 0 0 0.956863 0 0 0 0 0.956863 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_993_10651"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_993_10651" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="-3"/>
+<feGaussianBlur stdDeviation="3"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.992157 0 0 0 0 0.976471 0 0 0 0 0.94902 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_993_10651"/>
+</filter>
+<clipPath id="bgblur_0_993_10651_clip_path" transform="translate(-16 -24)"><rect x="22" y="30" width="57" height="69" rx="6"/>
+</clipPath><filter id="filter2_di_993_10651" x="49.0234" y="35.125" width="71.4102" height="71.4062" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="3" dy="3"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.870588 0 0 0 0 0.870588 0 0 0 0 0.870588 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_993_10651"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_993_10651" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="-3" dy="-3"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.870588 0 0 0 0 0.870588 0 0 0 0 0.870588 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_993_10651"/>
+</filter>
+<clipPath id="bgblur_1_993_10651_clip_path" transform="translate(-49.0234 -35.125)"><path d="M101.993 58.3606C102.579 58.9464 102.579 59.8961 101.993 60.4819L75.6634 86.812C75.1563 87.3191 74.4843 87.6284 73.7692 87.6828L62.6364 88.5266C61.7205 88.5961 60.958 87.8336 61.0275 86.9176L61.872 75.7855C61.9263 75.0704 62.2349 74.3979 62.7421 73.8907L79.7955 56.8373L92.7161 69.7579L95.3008 67.1732L82.3802 54.2526L89.0722 47.5607C89.6579 46.9749 90.6077 46.9749 91.1935 47.5607L101.993 58.3606Z"/>
+</clipPath><filter id="filter3_di_993_10651" x="14.5" y="25.5" width="84" height="51" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="6" dy="6"/>
+<feGaussianBlur stdDeviation="12"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.981102 0 0 0 0 0.716495 0 0 0 0 0.30018 0 0 0 0.04 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_993_10651"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_993_10651" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="12" dy="12"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.980392 0 0 0 0 0.952941 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_993_10651"/>
+</filter>
+<clipPath id="bgblur_2_993_10651_clip_path" transform="translate(-14.5 -25.5)"><rect x="32.5" y="43.5" width="36" height="3" rx="1.5"/>
+</clipPath><filter id="filter4_di_993_10651" x="14.5" y="36" width="84" height="51" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="6" dy="6"/>
+<feGaussianBlur stdDeviation="12"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.981102 0 0 0 0 0.716495 0 0 0 0 0.30018 0 0 0 0.04 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_993_10651"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_993_10651" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="12" dy="12"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.980392 0 0 0 0 0.952941 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_993_10651"/>
+</filter>
+<clipPath id="bgblur_3_993_10651_clip_path" transform="translate(-14.5 -36)"><rect x="32.5" y="54" width="36" height="3" rx="1.5"/>
+</clipPath><filter id="filter5_di_993_10651" x="14.5" y="46.5" width="72" height="51" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="6" dy="6"/>
+<feGaussianBlur stdDeviation="12"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.981102 0 0 0 0 0.716495 0 0 0 0 0.30018 0 0 0 0.04 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_993_10651"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_993_10651" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="12" dy="12"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.980392 0 0 0 0 0.952941 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_993_10651"/>
+</filter>
+<clipPath id="bgblur_4_993_10651_clip_path" transform="translate(-14.5 -46.5)"><rect x="32.5" y="64.5" width="24" height="3" rx="1.5"/>
+</clipPath><filter id="filter6_di_993_10651" x="14.5" y="57" width="63" height="51" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="6" dy="6"/>
+<feGaussianBlur stdDeviation="12"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.981102 0 0 0 0 0.716495 0 0 0 0 0.30018 0 0 0 0.04 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_993_10651"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_993_10651" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="12" dy="12"/>
+<feGaussianBlur stdDeviation="7.5"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 0.980392 0 0 0 0 0.952941 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="shape" result="effect2_innerShadow_993_10651"/>
+</filter>
+<clipPath id="bgblur_5_993_10651_clip_path" transform="translate(-14.5 -57)"><rect x="32.5" y="75" width="15" height="3" rx="1.5"/>
+</clipPath><linearGradient id="paint0_linear_993_10651" x1="22.5" y1="16.5" x2="91.5" y2="109.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F4F3F2"/>
+<stop offset="1" stop-color="#F4F3F2"/>
+</linearGradient>
+<linearGradient id="paint1_linear_993_10651" x1="50.5" y1="30" x2="50.5" y2="99" gradientUnits="userSpaceOnUse">
+<stop stop-color="#DADADA" stop-opacity="0.4"/>
+<stop offset="1" stop-color="#DADADA" stop-opacity="0.8"/>
+</linearGradient>
+<linearGradient id="paint2_linear_993_10651" x1="90.9426" y1="51.687" x2="95.2923" y2="78.9438" gradientUnits="userSpaceOnUse">
+<stop stop-color="#DEDEDE"/>
+<stop offset="0.5" stop-color="#DEDEDE"/>
+<stop offset="1" stop-color="#DEDEDE"/>
+</linearGradient>
+<linearGradient id="paint3_linear_993_10651" x1="40.8538" y1="43.6869" x2="40.9737" y2="46.5219" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FCFCFC"/>
+<stop offset="0.5" stop-color="#FCFCFC"/>
+<stop offset="1" stop-color="#FCFCFC"/>
+</linearGradient>
+<linearGradient id="paint4_linear_993_10651" x1="40.8538" y1="54.1869" x2="40.9737" y2="57.0219" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FCFCFC"/>
+<stop offset="0.5" stop-color="#FCFCFC"/>
+<stop offset="1" stop-color="#FCFCFC"/>
+</linearGradient>
+<linearGradient id="paint5_linear_993_10651" x1="38.0692" y1="64.6869" x2="38.2486" y2="67.5156" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FCFCFC"/>
+<stop offset="0.5" stop-color="#FCFCFC"/>
+<stop offset="1" stop-color="#FCFCFC"/>
+</linearGradient>
+<linearGradient id="paint6_linear_993_10651" x1="35.9807" y1="75.1869" x2="36.2661" y2="77.998" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FCFCFC"/>
+<stop offset="0.5" stop-color="#FCFCFC"/>
+<stop offset="1" stop-color="#FCFCFC"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/app/(public)/albatalk/[id]/page.tsx
+++ b/src/app/(public)/albatalk/[id]/page.tsx
@@ -1,0 +1,12 @@
+import AlbatalkDetail from '@/features/albatalk/components/albatalk-detail';
+import mockAlbatalkComments from '@/features/albatalk/mocks/mockAlbatalkComments';
+import mockAlbatalkDetail from '@/features/albatalk/mocks/mockAlbatalkDetail';
+
+const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const { id } = await params;
+  const albatalkData = mockAlbatalkDetail;
+  const commentsData = mockAlbatalkComments;
+  return <AlbatalkDetail comments={commentsData} data={albatalkData} />;
+};
+
+export default Page;

--- a/src/app/(public)/albatalk/layout.tsx
+++ b/src/app/(public)/albatalk/layout.tsx
@@ -1,0 +1,13 @@
+import InnerContainer from '@/shared/components/container/InnerContainer';
+
+const AlbaTalkLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div>
+      <main>
+        <InnerContainer>{children}</InnerContainer>
+      </main>
+    </div>
+  );
+};
+
+export default AlbaTalkLayout;

--- a/src/app/(public)/albatalk/page.tsx
+++ b/src/app/(public)/albatalk/page.tsx
@@ -1,12 +1,7 @@
 import PostList from '@/features/albatalk/components/post-list';
-import InnerContainer from '@/shared/components/container/InnerContainer';
 
 const AlbaTalkPage = () => {
-  return (
-    <InnerContainer>
-      <PostList />
-    </InnerContainer>
-  );
+  return <PostList />;
 };
 
 export default AlbaTalkPage;

--- a/src/features/albatalk/components/albatalk-detail/AlbatalkDetailContent.tsx
+++ b/src/features/albatalk/components/albatalk-detail/AlbatalkDetailContent.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@/shared/lib/cn';
+
+interface AlbatalkDetailContentProps {
+  content: string;
+  className?: string;
+}
+
+const AlbatalkDetailContent = ({
+  content,
+  className,
+}: AlbatalkDetailContentProps) => {
+  return (
+    <div className={cn('text-sm md:text-base lg:text-xl', className)}>
+      {content}
+    </div>
+  );
+};
+
+export default AlbatalkDetailContent;

--- a/src/features/albatalk/components/albatalk-detail/AlbatalkDetailHeader.tsx
+++ b/src/features/albatalk/components/albatalk-detail/AlbatalkDetailHeader.tsx
@@ -1,0 +1,31 @@
+import { PostDetailResponse } from '../../types/albatalk';
+import PostCardHeader from '../post-item/PostCardHeader';
+import PostMetaInfo from '../post-item/PostMetaInfo';
+
+interface AlbatalkDetailHeaderProps {
+  data: PostDetailResponse;
+}
+
+const AlbatalkDetailHeader = ({ data }: AlbatalkDetailHeaderProps) => {
+  const { title, id, createdAt, commentCount, likeCount, writer } = data;
+  return (
+    <div className="flex flex-col gap-16">
+      <PostCardHeader
+        className="border-b border-gray-200"
+        postId={id}
+        title={title}
+        titleClassName="pb-16 md:text-xl lg:text-2xl"
+      />
+      <PostMetaInfo
+        className="text-gray-500 lg:text-base"
+        commentCount={commentCount}
+        createdAt={createdAt}
+        initialLikeCount={likeCount}
+        postId={id}
+        writer={writer}
+      />
+    </div>
+  );
+};
+
+export default AlbatalkDetailHeader;

--- a/src/features/albatalk/components/albatalk-detail/CommentForm.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentForm.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useRef } from 'react';
+
+import PrimaryButton from '@/shared/components/common/button/PrimaryButton';
+import Textarea from '@/shared/components/common/input/Textarea';
+
+interface CommentFormProps {
+  postId: number;
+  onSubmit?: (content: string) => void;
+}
+
+const CommentForm = ({ postId, onSubmit }: CommentFormProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSubmit = () => {
+    const content = textareaRef.current?.value ?? '';
+    if (!content.trim()) return;
+    onSubmit?.(content);
+    if (textareaRef.current) {
+      textareaRef.current.value = '';
+    }
+    //TODO: 실제 댓글 등록 API 호출
+    console.log('댓글 등록: ', { postId, content });
+  };
+
+  return (
+    <div className="flex flex-col rounded-lg lg:mb-16">
+      <Textarea
+        ref={textareaRef}
+        required
+        className=""
+        id="commentContent"
+        placeholder="댓글을 작성해주세요."
+      />
+      <div className="mt-8 flex w-108 self-end">
+        <PrimaryButton
+          className="w-full max-w-640 py-12 text-lg lg:text-xl"
+          disabled={false}
+          label="등록하기"
+          type="button"
+          variant="solid"
+          onClick={handleSubmit}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default CommentForm;

--- a/src/features/albatalk/components/albatalk-detail/CommentItem.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentItem.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import PrimaryButton from '@/shared/components/common/button/PrimaryButton';
+import Textarea from '@/shared/components/common/input/Textarea';
+import KebabMenuDropdown from '@/shared/components/common/kebabMenuDropdown';
+
+import { Comment } from '../../types/albatalk';
+import PostMetaInfoUser from '../post-item/PostMetaInfoUser';
+
+interface CommentItemProps {
+  comment: Comment;
+  onEdit: (commentId: number, newContent: string) => void;
+  onDelete: (commentId: number) => void;
+}
+
+const CommentItem = ({ comment, onEdit, onDelete }: CommentItemProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.value = comment.content;
+      textareaRef.current.focus();
+    }
+  }, [isEditing, comment.content]);
+
+  const handleActionClick = (option: string) => {
+    if (option === 'edit') {
+      setIsEditing(true);
+    } else if (option === 'delete') {
+      onDelete(comment.id);
+    }
+  };
+
+  const menuOptions = [
+    { label: '수정하기', onClick: () => handleActionClick('edit') },
+    { label: '삭제하기', onClick: () => handleActionClick('delete') },
+  ];
+
+  const handleConfirmEdit = () => {
+    const newContent = textareaRef.current?.value || '';
+
+    if (newContent.trim() === '') {
+      alert('댓글 내용을 입력해주세요.');
+      return;
+    }
+    onEdit(comment.id, newContent);
+    setIsEditing(false);
+  };
+
+  const handleCancelEdit = () => {
+    if (textareaRef.current) {
+      textareaRef.current.value = comment.content;
+    }
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="flex flex-col items-start gap-24 border-b border-gray-100 py-16 last:border-b-0">
+      <div className="flex w-full justify-between text-xs text-gray-500 lg:text-base">
+        <PostMetaInfoUser
+          createdAt={comment.createdAt}
+          writer={comment.writer}
+        />
+        <KebabMenuDropdown options={menuOptions} />
+      </div>
+
+      {isEditing ? (
+        // 수정 모드일 때 (textarea와 버튼들을 보여줌)
+        <div className="flex w-full flex-col gap-16 pl-4">
+          <Textarea
+            ref={textareaRef}
+            required
+            id="commentContent"
+            placeholder="댓글을 작성해주세요."
+          />
+          <div className="flex w-208 gap-8 self-end">
+            <PrimaryButton
+              className="w-full py-12 text-lg text-black lg:text-xl"
+              label="취소"
+              type="button"
+              variant="cancelSolid"
+              onClick={handleCancelEdit}
+            />
+            <PrimaryButton
+              className="w-full py-12 text-lg lg:text-xl"
+              label="확인"
+              type="button"
+              variant="solid"
+              onClick={handleConfirmEdit}
+            />
+          </div>
+        </div>
+      ) : (
+        // 일반 보기 모드일 때 (댓글 내용을 보여줌)
+        <p className="pl-4 text-sm leading-relaxed md:text-base lg:text-xl">
+          {comment.content}
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default CommentItem;

--- a/src/features/albatalk/components/albatalk-detail/CommentList.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentList.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import Image from 'next/image';
+import { useState } from 'react';
+
+import { Comment } from '../../types/albatalk';
+import CommentItem from './CommentItem';
+
+interface CommentListProps {
+  initialComments: Comment[];
+}
+
+const CommentList = ({ initialComments }: CommentListProps) => {
+  const [comments, setComments] = useState(initialComments || []);
+
+  console.log(comments);
+
+  // 댓글 수정 로직을 처리하는 함수
+  const handleEditComment = (commentId: number, newContent: string) => {
+    // TODO: 여기에 실제 API 호출 로직 (서버에 댓글 수정 요청)
+    console.log(
+      `[CommentList] 댓글 ID: ${commentId}, 새로운 내용: "${newContent}" 수정 요청`
+    );
+
+    // API 호출 성공 시, 상태 업데이트
+    setComments(prevComments =>
+      prevComments.map(comment =>
+        comment.id === commentId ? { ...comment, content: newContent } : comment
+      )
+    );
+  };
+
+  // 댓글 삭제 로직을 처리하는 함수
+  const handleDeleteComment = (commentId: number) => {
+    // TODO: 여기에 실제 API 호출 로직 (서버에 댓글 삭제 요청)
+    console.log(`[CommentList] 댓글 ID: ${commentId} 삭제 요청`);
+
+    // API 호출 성공 시, 상태 업데이트
+    setComments(prevComments =>
+      prevComments.filter(comment => comment.id !== commentId)
+    );
+  };
+
+  if (comments.length === 0) {
+    return (
+      <div className="my-100 flex flex-col gap-32 self-center text-center">
+        <Image
+          alt="empty-list"
+          className="self-center"
+          height={120}
+          src="/icons/empty-list.svg"
+          width={120}
+        />
+        <div>
+          <p className="mb-1 text-gray-500">등록된 댓글이 없어요</p>
+          <p className="text-sm text-gray-400">댓글을 등록해서 소통해주세요</p>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-16 space-y-1">
+      {comments.map(comment => (
+        <CommentItem
+          key={comment.id}
+          comment={comment}
+          onDelete={handleDeleteComment}
+          onEdit={handleEditComment}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CommentList;

--- a/src/features/albatalk/components/albatalk-detail/CommentSection.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentSection.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useState } from 'react';
+
+import { CommentsResponse } from '../../types/albatalk';
+import CommentForm from './CommentForm';
+import CommentList from './CommentList';
+import CommentStats from './CommentStatus';
+
+interface CommentSectionProps {
+  postId: number;
+  initialComments: CommentsResponse;
+}
+
+const CommentSection = ({ postId, initialComments }: CommentSectionProps) => {
+  const [comments, setComments] = useState(initialComments);
+  return (
+    <div className="flex flex-col gap-24 lg:gap-40">
+      <CommentStats count={initialComments.totalItemCount} />
+      <CommentForm postId={postId} />
+      <CommentList initialComments={comments.data} />
+    </div>
+  );
+};
+
+export default CommentSection;

--- a/src/features/albatalk/components/albatalk-detail/CommentStatus.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentStatus.tsx
@@ -1,0 +1,15 @@
+interface CommentStatsProps {
+  count: number;
+}
+
+const CommentStats = ({ count }: CommentStatsProps) => {
+  return (
+    <div className="border-b border-gray-200">
+      <h3 className="mt-100 mb-16 text-lg font-semibold md:text-xl lg:text-2xl">
+        댓글({count})
+      </h3>
+    </div>
+  );
+};
+
+export default CommentStats;

--- a/src/features/albatalk/components/albatalk-detail/index.tsx
+++ b/src/features/albatalk/components/albatalk-detail/index.tsx
@@ -1,0 +1,21 @@
+import { CommentsResponse, PostDetailResponse } from '../../types/albatalk';
+import AlbatalkDetailContent from './AlbatalkDetailContent';
+import AlbatalkDetailHeader from './AlbatalkDetailHeader';
+import CommentSection from './CommentSection';
+
+interface AlbatalkDetailProps {
+  data: PostDetailResponse;
+  comments: CommentsResponse;
+}
+
+const AlbatalkDetail = ({ data, comments }: AlbatalkDetailProps) => {
+  return (
+    <div className="flex flex-col gap-40 pt-44">
+      <AlbatalkDetailHeader data={data} />
+      <AlbatalkDetailContent content={data.content} />
+      <CommentSection initialComments={comments} postId={data.id} />
+    </div>
+  );
+};
+
+export default AlbatalkDetail;

--- a/src/features/albatalk/components/post-item/PostCardHeader.tsx
+++ b/src/features/albatalk/components/post-item/PostCardHeader.tsx
@@ -1,32 +1,21 @@
 'use client';
-import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
 
-import AlbaDropdown from '@/features/albalist/components/AlbaDropdown';
+import KebabMenuDropdown from '@/shared/components/common/kebabMenuDropdown';
+import { cn } from '@/shared/lib/cn';
 
 interface PostHeaderProps {
   title: string;
   postId: number;
+  className?: string;
+  titleClassName?: string;
 }
 
-const PostCardHeader = ({ title, postId }: PostHeaderProps) => {
-  const [open, setOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open]);
-
+const PostCardHeader = ({
+  title,
+  postId,
+  className,
+  titleClassName,
+}: PostHeaderProps) => {
   const handleActionClick = (option: string) => {
     if (option === 'edit') {
       //TODO: 수정 로직
@@ -34,7 +23,6 @@ const PostCardHeader = ({ title, postId }: PostHeaderProps) => {
     } else if (option === 'delete') {
       //TODO: 삭제 로직
     }
-    setOpen(false); // 클릭 후 드롭다운 닫기
   };
 
   const menuOptions = [
@@ -43,33 +31,16 @@ const PostCardHeader = ({ title, postId }: PostHeaderProps) => {
   ];
 
   return (
-    <div className="mb-8 flex items-start justify-between">
-      <h2 className="mr-12 line-clamp-2 flex-1 text-lg font-semibold break-words text-gray-900 dark:text-white">
+    <div className={cn('mb-8 flex items-start justify-between', className)}>
+      <h2
+        className={cn(
+          'mr-12 line-clamp-2 flex-1 text-lg font-semibold break-words text-gray-900 dark:text-white',
+          titleClassName
+        )}
+      >
         {title}
       </h2>
-      <div ref={dropdownRef} className="relative ml-auto">
-        <Image
-          alt="드롭다운 아이콘"
-          className="cursor-pointer"
-          height={24}
-          role="button"
-          src="/icons/kebab-menu.svg"
-          tabIndex={0}
-          width={24}
-          onClick={e => {
-            e.stopPropagation();
-            setOpen(prev => !prev);
-          }}
-          onKeyDown={e => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              e.stopPropagation();
-              setOpen(prev => !prev);
-            }
-          }}
-        />
-        {open && <AlbaDropdown options={menuOptions} />}
-      </div>
+      <KebabMenuDropdown options={menuOptions} />
     </div>
   );
 };

--- a/src/features/albatalk/components/post-item/PostMetaInfo.tsx
+++ b/src/features/albatalk/components/post-item/PostMetaInfo.tsx
@@ -1,10 +1,11 @@
+'use client';
 import Image from 'next/image';
 import React, { useState } from 'react';
 
 import { Writer } from '@/features/albatalk/types/albatalk';
-import Profile from '@/shared/components/common/profile/Profile';
 import { cn } from '@/shared/lib/cn';
-import { formatDate } from '@/shared/utils/date';
+
+import PostMetaInfoUser from './PostMetaInfoUser';
 
 interface PostMetaInfoProps {
   writer: Writer;
@@ -30,36 +31,22 @@ const PostMetaInfo = ({
   const handleLikeToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
 
-    setIsLiked(prev => {
-      const newIsLiked = !prev;
-      setLikeCount(prevCount => (prev ? prevCount - 1 : prevCount + 1));
-      console.log(`좋아요 ${prev ? '취소' : '추가'} : ${postId}`);
-      return newIsLiked;
-    });
+    if (isLiked) {
+      setIsLiked(false);
+      setLikeCount(prevCount => prevCount - 1);
+      console.log(`좋아요 취소 : ${postId}`);
+    } else {
+      setIsLiked(true);
+      setLikeCount(prevCount => prevCount + 1);
+      console.log(`좋아요 추가 : ${postId}`);
+    }
   };
 
   return (
     <div
       className={cn('flex justify-between text-xs text-gray-500', className)}
     >
-      <div className="flex items-center gap-7">
-        {/* 프로필 이미지 */}
-        <div className="size-26">
-          {writer.imageUrl ? (
-            <Profile
-              className="size-26 border-none lg:size-26"
-              imageUrl={writer.imageUrl}
-            />
-          ) : (
-            <Profile className="size-26 border-none lg:size-26" sizes="26px" />
-          )}
-        </div>
-        {/* 닉네임 */}
-        <span>{writer.nickname}</span>
-        <div className="h-12 w-px bg-line-200" />
-        {/* 날짜 */}
-        <time>{formatDate(createdAt, 'post')}</time>
-      </div>
+      <PostMetaInfoUser createdAt={createdAt} writer={writer} />
 
       <div className="flex gap-12">
         {/* 댓글 수 */}
@@ -74,11 +61,12 @@ const PostMetaInfo = ({
         </div>
 
         {/* 좋아요 */}
-        <div className="flex" onClick={handleLikeToggle}>
+        <div className="flex">
           <button
             aria-label="좋아요 버튼"
             className="transition-transform duration-150 hover:scale-110 active:scale-95"
             type="button"
+            onClick={handleLikeToggle}
           >
             <Image alt="like_icon" height={24} src={likeIconSrc} width={24} />
           </button>

--- a/src/features/albatalk/components/post-item/PostMetaInfoUser.tsx
+++ b/src/features/albatalk/components/post-item/PostMetaInfoUser.tsx
@@ -1,0 +1,34 @@
+import Profile from '@/shared/components/common/profile/Profile';
+import { formatDate } from '@/shared/utils/date';
+
+import { Writer } from '../../types/albatalk';
+
+interface PostMetaInfoUserProps {
+  writer: Writer;
+  createdAt: string;
+}
+
+const PostMetaInfoUser = ({ writer, createdAt }: PostMetaInfoUserProps) => {
+  return (
+    <div className="flex items-center gap-7">
+      {/* 프로필 이미지 */}
+      <div className="size-26">
+        {writer.imageUrl ? (
+          <Profile
+            className="size-26 border-none lg:size-26"
+            imageUrl={writer.imageUrl}
+          />
+        ) : (
+          <Profile className="size-26 border-none lg:size-26" sizes="26px" />
+        )}
+      </div>
+      {/* 닉네임 */}
+      <span>{writer.nickname}</span>
+      <div className="h-12 w-px bg-line-200" />
+      {/* 날짜 */}
+      <time>{formatDate(createdAt, 'post')}</time>
+    </div>
+  );
+};
+
+export default PostMetaInfoUser;

--- a/src/features/albatalk/components/post-item/index.tsx
+++ b/src/features/albatalk/components/post-item/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { Post } from '@/features/albatalk/types/albatalk';
 
 import PostCardHeader from './PostCardHeader';
-import PostFooter from './PostMetaInfo';
+import PostMetaInfo from './PostMetaInfo';
 
 interface PostItemProps {
   post: Post;
@@ -25,7 +25,7 @@ const PostItem = ({ post }: PostItemProps) => {
       return;
     }
 
-    router.push(`/post/${post.id}`);
+    router.push(`/albatalk/${post.id}`);
   };
 
   return (
@@ -39,7 +39,7 @@ const PostItem = ({ post }: PostItemProps) => {
           {post.content}
         </p>
       </div>
-      <PostFooter
+      <PostMetaInfo
         commentCount={post.commentCount}
         createdAt={post.createdAt}
         initialLikeCount={post.likeCount}

--- a/src/features/albatalk/components/post-list/PostFilterBar.tsx
+++ b/src/features/albatalk/components/post-list/PostFilterBar.tsx
@@ -48,9 +48,9 @@ const PostFilterBar = () => {
       />
       <div className="justify-items-end lg:self-center">
         <Select
-          className="mt-8"
           options={sortOptions}
           variant="sort"
+          wrapperClassName="mt-8"
           onSelect={handleSortChange}
         />
       </div>

--- a/src/features/albatalk/mocks/mockAlbatalkComments.ts
+++ b/src/features/albatalk/mocks/mockAlbatalkComments.ts
@@ -1,0 +1,33 @@
+import { CommentsResponse } from '../types/albatalk';
+
+const mockAlbatalkComments: CommentsResponse = {
+  data: [
+    {
+      id: 436,
+      content: '안녕하세요~',
+      createdAt: '2025-07-19T11:42:08.966Z',
+      updatedAt: '2025-07-19T11:42:08.966Z',
+      writer: {
+        id: 446,
+        nickname: '펭귄',
+        imageUrl: null,
+      },
+    },
+    {
+      id: 435,
+      content: '좋은 알바 추천해주세요!!',
+      createdAt: '2025-07-19T10:27:36.687Z',
+      updatedAt: '2025-07-19T10:27:36.687Z',
+      writer: {
+        id: 446,
+        nickname: '펭귄',
+        imageUrl: null,
+      },
+    },
+  ],
+  totalItemCount: 2,
+  currentPage: 1,
+  totalPages: 1,
+};
+
+export default mockAlbatalkComments;

--- a/src/features/albatalk/mocks/mockAlbatalkDetail.ts
+++ b/src/features/albatalk/mocks/mockAlbatalkDetail.ts
@@ -1,0 +1,21 @@
+import { PostDetailResponse } from '../types/albatalk';
+
+const mockAlbatalkDetail: PostDetailResponse = {
+  id: 370,
+  title: 'ㅂㅈㄷㄱ',
+  content: 'ㅂㅈㄷㄱ',
+  imageUrl:
+    'https://sprint-fe-project.s3.ap-northeast-2.amazonaws.com/Albaform/user/414/1752617866179/coplan.png',
+  likeCount: 0,
+  commentCount: 0,
+  createdAt: '2025-07-15T22:17:48.422Z',
+  updatedAt: '2025-07-15T22:17:48.422Z',
+  writer: {
+    id: 414,
+    nickname: '초지동얼음공주',
+    imageUrl: null,
+  },
+  isLiked: false,
+};
+
+export default mockAlbatalkDetail;

--- a/src/features/albatalk/types/albatalk.ts
+++ b/src/features/albatalk/types/albatalk.ts
@@ -21,9 +21,28 @@ export interface PostsResponse {
   nextCursor: number | null;
 }
 
+export interface PostDetailResponse extends Post {
+  isLiked: boolean;
+}
+
 export interface GetPostsParams {
   limit: number;
   cursor?: number;
   orderBy?: 'mostRecent' | 'mostCommented' | 'mostLiked';
   keyword?: string;
+}
+
+export interface Comment {
+  id: number;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  writer: Writer;
+}
+
+export interface CommentsResponse {
+  data: Comment[];
+  totalItemCount: number;
+  currentPage: number;
+  totalPages: number;
 }

--- a/src/shared/components/common/kebabMenuDropdown/index.tsx
+++ b/src/shared/components/common/kebabMenuDropdown/index.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+
+import AlbaDropdown from '@/shared/components/common/list/AlbaDropdown'; // 경로 확인
+import { useClickOutside } from '@/shared/hooks/useClickOutside'; // 경로 확인
+
+interface KebabMenuDropdownProps {
+  options: { label: string; onClick: () => void }[];
+}
+
+const KebabMenuDropdown = ({ options }: KebabMenuDropdownProps) => {
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  useClickOutside(dropdownRef, () => {
+    if (open) {
+      setOpen(false);
+    }
+  });
+
+  const handleToggle = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation();
+    setOpen(prev => !prev);
+  };
+
+  return (
+    <div ref={dropdownRef} className="relative ml-auto">
+      <Image
+        alt="드롭다운 아이콘"
+        className="cursor-pointer"
+        height={24}
+        role="button"
+        src="/icons/kebab-menu.svg"
+        tabIndex={0}
+        width={24}
+        onClick={handleToggle}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleToggle(e); // 키보드 이벤트도 handleToggle로 처리
+          }
+        }}
+      />
+      {open && <AlbaDropdown options={options} />}
+    </div>
+  );
+};
+
+export default KebabMenuDropdown;


### PR DESCRIPTION
## 📝 PR 내용 요약

- 알바톡 상세페이지 기본 구조 및 UI 컴포넌트 구현

---

## ✨ 주요 변경사항

- 타입 정의: PostDetailResponse, Comment, CommentsResponse 인터페이스 추가
- 목데이터: mockAlbatalkDetail, mockAlbatalkComments 생성
- 알바토크 상세 헤더: 제목, 메타정보(작성자, 날짜, 좋아요) 표시 컴포넌트
- 댓글 시스템: 댓글 목록, 작성폼 컴포넌트 구현
- 라우팅: /albatalk/[id] 동적 라우팅 설정
- 공통 컴포넌트: KebabMenuDropdown을 shared 컴포넌트로 분리하여 재사용성 향상

## 🧩 관련 이슈

- Close #83 

---

## 📸 스크린샷 (선택)

![화면 기록 2025-07-20 오전 6 53 03](https://github.com/user-attachments/assets/f543ba0c-aa3c-4f04-b0d2-ce991d99c179)

- 등록된 댓글이 없을 때
<img width="1509" height="698" alt="image" src="https://github.com/user-attachments/assets/162d3684-2649-4dd8-9225-d538b96cf364" />


---

## 💬 참고 사항

- `/albatalk/370` 접속하여 상세페이지 UI 확인이 가능합니다.
- 알바토크 상세페이지 안에 컴포넌트를 쪼개다보니 파일이 많이 추가되었습니다... 😭

---

## 📌 후속 작업

- 실제 API 연동
- 댓글 CRUD 기능 구현
- 무한스크롤 적용
- 좋아요 기능 추가
