### PR TITLE
[feat] 알바 폼 상세 페이지의 이미지 캐러셀 구현

### DIFF
--- a/src/app/test/hyeran/HyeranClientTest.tsx
+++ b/src/app/test/hyeran/HyeranClientTest.tsx
@@ -10,7 +10,11 @@ import Image from 'next/image';
 import { useState } from 'react';
 
 import ThemeToggle from '@/shared/components/ThemeToggle';
+import ImageCarousel from '@/shared/components/ui/ImageCarousel';
 import useModalStore from '@/shared/store/useModalStore';
+import { Slide } from '@/shared/types/carousel';
+import { createSlidesFromUrls } from '@/shared/utils/carousel';
+
 const RADIO_OPTIONS: RadioOption[] = [
   { value: 'REJECTED', label: '거절' },
   { value: 'INTERVIEW_PENDING', label: '면접대기' },
@@ -228,6 +232,15 @@ const HyeranClientTest = () => {
     );
   };
 
+  // 캐러셀 예시
+  const sampleImages = [
+    '/images/landing/albaform-clock.png',
+    '/images/landing/apply-girl.png',
+    '/images/landing/anywhere-application.png',
+  ];
+
+  const sampleSlides: Slide[] = createSlidesFromUrls(sampleImages);
+
   return (
     <div className="flex flex-col gap-20">
       <ThemeToggle />
@@ -287,13 +300,6 @@ const HyeranClientTest = () => {
             onClick={handleBookmarkToggle}
           />
           <FloatingButton type="share" />
-        </FloatingButtonContainer>
-        <FloatingButtonContainer>
-          <FloatingButton
-            href="/forms/create"
-            text="폼 만들기"
-            type="addForm"
-          />
         </FloatingButtonContainer>
       </section>
       <section>
@@ -376,7 +382,19 @@ const HyeranClientTest = () => {
           >
             내 지원 내역 모달
           </button>
+          <div>
+            <FloatingButtonContainer>
+              <FloatingButton
+                href="/forms/create"
+                text="폼 만들기"
+                type="addForm"
+              />
+            </FloatingButtonContainer>
+          </div>
         </div>
+      </section>
+      <section>
+        <ImageCarousel showCounter interval={4000} slides={sampleSlides} />
       </section>
     </div>
   );

--- a/src/shared/components/common/button/FloatingButtonContainer.tsx
+++ b/src/shared/components/common/button/FloatingButtonContainer.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { Z_INDEX } from '@/shared/constants/zIndex';
-
 /**
  * FloatingButtonContainer 컴포넌트의 Props 인터페이스
  */
@@ -54,7 +52,7 @@ const FloatingButtonContainer: React.FC<FloatingButtonContainerProps> = ({
    * @returns 포지션에 맞는 CSS 클래스 문자열
    */
   const getPositionClasses = (): string => {
-    const baseClasses = `fixed flex flex-col gap-24 z-[${Z_INDEX.FLOATING_BUTTON}}]`;
+    const baseClasses = 'fixed flex flex-col gap-24 z-1000';
 
     if (position === 'right-center') {
       return `${baseClasses} right-23 top-1/2 lg:right-220 transform -translate-y-1/2`;

--- a/src/shared/components/common/modal/ModalOverlay.tsx
+++ b/src/shared/components/common/modal/ModalOverlay.tsx
@@ -6,8 +6,6 @@
 
 import React from 'react';
 
-import { Z_INDEX } from '@/shared/constants/zIndex';
-
 interface ModalOverlayProps {
   children: React.ReactNode;
   onClose?: () => void;
@@ -21,7 +19,7 @@ const ModalOverlay: React.FC<ModalOverlayProps> = ({
 }) => {
   return (
     <div
-      className={`fixed inset-0 z-[${Z_INDEX.MODAL}] flex items-center justify-center bg-black-100/50`}
+      className="fixed inset-0 z-1040 flex items-center justify-center bg-black-100/50"
       onClick={closeOnOverlayClick ? onClose : undefined}
     >
       {children}

--- a/src/shared/components/common/pagination/Indicator.tsx
+++ b/src/shared/components/common/pagination/Indicator.tsx
@@ -1,16 +1,19 @@
 interface IndicatorProps {
   current: number;
   total: number;
+  onIndicatorClick?: (index: number) => void;
 }
 
-const Indicator = ({ current, total }: IndicatorProps) => {
+const Indicator = ({ current, total, onIndicatorClick }: IndicatorProps) => {
   return (
     <div className="hidden items-center justify-center gap-22 lg:flex">
       {Array.from({ length: total }, (_, i) => {
         return (
-          <div
+          <button
             key={`${i}`}
             className={`rounded-full ${current === i ? 'h-16 w-16 bg-gray-300/60' : 'h-12 w-12 bg-line-100/60'}`}
+            type="button"
+            onClick={() => onIndicatorClick?.(i)}
           />
         );
       })}

--- a/src/shared/components/ui/ImageCarousel.tsx
+++ b/src/shared/components/ui/ImageCarousel.tsx
@@ -1,0 +1,171 @@
+'use client';
+import Image from 'next/image';
+import React, { useEffect, useRef } from 'react';
+
+import useCarousel from '@/shared/hooks/useCarousel';
+import { useSwipeGesture } from '@/shared/hooks/useSwipeGesture';
+import { cn } from '@/shared/lib/cn';
+import { CarouselProps } from '@/shared/types/carousel';
+
+import CardPagination from '../common/pagination/CardPagination';
+import Indicator from '../common/pagination/Indicator';
+
+const ImageCarousel: React.FC<CarouselProps> = ({
+  slides,
+  interval = 4000,
+  showCounter = true,
+  className = '',
+  ...props
+}) => {
+  const { currentSlide, isAutoPlaying, goToSlide, nextSlide, prevSlide } =
+    useCarousel({ totalSlides: slides.length });
+
+  const { handleTouchStart, handleTouchMove, handleTouchEnd } = useSwipeGesture(
+    {
+      onSwipeLeft: nextSlide,
+      onSwipeRight: prevSlide,
+    }
+  );
+
+  const carouselRef = useRef<HTMLDivElement>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // 자동 재생 관리
+  useEffect(() => {
+    if (!isAutoPlaying || slides.length <= 1) return;
+
+    intervalRef.current = setInterval(() => {
+      nextSlide();
+    }, interval);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [nextSlide, isAutoPlaying, interval, slides.length]);
+
+  // 키보드 네비게이션
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      switch (e.key) {
+        case 'ArrowLeft':
+          e.preventDefault();
+          prevSlide();
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          nextSlide();
+          break;
+        case 'Home':
+          e.preventDefault();
+          goToSlide(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          goToSlide(slides.length - 1);
+          break;
+      }
+    };
+
+    const carousel = carouselRef.current;
+    if (carousel) {
+      carousel.addEventListener('keydown', handleKeyDown);
+      return () => carousel.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [prevSlide, nextSlide, goToSlide, slides.length]);
+
+  // 마우스 이벤트 핸들러 - 호버로 자동재생 제어
+  const handleMouseEnter = (): void => {
+    // 마우스가 올라오면 자동재생 정지
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+  };
+
+  const handleMouseLeave = (): void => {
+    // 마우스가 벗어나면 자동재생 재시작
+    if (isAutoPlaying && slides.length > 1) {
+      intervalRef.current = setInterval(nextSlide, interval);
+    }
+  };
+
+  // 빈 슬라이드 처리
+  if (!slides || slides.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={carouselRef}
+      aria-label="이미지 캐러셀"
+      aria-live="polite"
+      className={cn(
+        'relative mx-auto h-260 w-full overflow-hidden rounded-2xl bg-white shadow-2xl lg:h-562',
+        className
+      )}
+      role="region"
+      tabIndex={0}
+      {...props}
+    >
+      {/* 메인 캐러셀 영역 */}
+      <div
+        className="group relative h-full w-full overflow-hidden"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onTouchEnd={handleTouchEnd}
+        onTouchMove={handleTouchMove}
+        onTouchStart={handleTouchStart}
+      >
+        {/* 슬라이드 컨테이너 */}
+        <div
+          aria-label={`슬라이드 ${currentSlide + 1} / ${slides.length}`}
+          className="flex h-full transition-transform duration-300 ease-out"
+          role="group"
+          style={{ transform: `translateX(-${currentSlide * 100}%)` }}
+        >
+          {slides.map((slide, index) => (
+            <div
+              key={slide.id}
+              aria-hidden={index !== currentSlide}
+              aria-label={slide.alt ?? '슬라이드'}
+              className="relative h-full min-w-full overflow-hidden"
+              role="tabpanel"
+            >
+              <Image
+                fill
+                alt={slide.alt ?? '슬라이드 이미지'}
+                className="object-cover"
+                priority={index === 0}
+                src={slide.image}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* 슬라이드 카운터 - 우측 하단으로 이동 */}
+        {showCounter && (
+          <div className="absolute right-4 bottom-4">
+            <CardPagination
+              currentPage={currentSlide + 1}
+              totalPage={slides.length}
+            />
+          </div>
+        )}
+
+        {/* 인디케이터 - 하단 가운데 */}
+        {slides.length > 1 && (
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 transform">
+            <Indicator
+              current={currentSlide}
+              total={slides.length}
+              onIndicatorClick={goToSlide}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ImageCarousel;

--- a/src/shared/hooks/useCarousel.ts
+++ b/src/shared/hooks/useCarousel.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useCallback, useEffect, useReducer } from 'react';
+
+import {
+  CarouselAction,
+  CarouselState,
+  UseCarouselProps,
+} from '../types/carousel';
+
+function reducer(state: CarouselState, action: CarouselAction): CarouselState {
+  switch (action.type) {
+    case 'GO_TO':
+      return { ...state, isTransitioning: true, currentSlide: action.index };
+    case 'NEXT':
+      return {
+        ...state,
+        isTransitioning: true,
+        currentSlide: (state.currentSlide + 1) % action.total,
+      };
+    case 'PREV':
+      return {
+        ...state,
+        isTransitioning: true,
+        currentSlide:
+          state.currentSlide === 0 ? action.total - 1 : state.currentSlide - 1,
+      };
+    case 'END_TRANSITION':
+      return { ...state, isTransitioning: false };
+    case 'TOGGLE_AUTOPLAY':
+      return { ...state, isAutoPlaying: !state.isAutoPlaying };
+    default:
+      return state;
+  }
+}
+
+export default function useCarousel({
+  totalSlides,
+  onSlideChange,
+}: UseCarouselProps) {
+  const [state, dispatch] = useReducer(reducer, {
+    currentSlide: 0,
+    isTransitioning: false,
+    isAutoPlaying: true,
+  });
+
+  // transition이 시작될 때 END_TRANSITION을 300ms 후에 dispatch
+  useEffect(() => {
+    if (state.isTransitioning) {
+      const timer = setTimeout(() => {
+        dispatch({ type: 'END_TRANSITION' });
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [state.isTransitioning]);
+
+  const goToSlide = useCallback(
+    (index: number) => {
+      if (state.isTransitioning || index < 0 || index >= totalSlides) return;
+      dispatch({ type: 'GO_TO', index });
+      onSlideChange?.(index);
+    },
+    [state.isTransitioning, totalSlides, onSlideChange]
+  );
+
+  const nextSlide = useCallback(() => {
+    if (state.isTransitioning) return;
+    dispatch({ type: 'NEXT', total: totalSlides });
+  }, [state.isTransitioning, totalSlides]);
+
+  const prevSlide = useCallback(() => {
+    if (state.isTransitioning) return;
+    dispatch({ type: 'PREV', total: totalSlides });
+  }, [state.isTransitioning, totalSlides]);
+
+  const toggleAutoPlay = useCallback(() => {
+    dispatch({ type: 'TOGGLE_AUTOPLAY' });
+  }, []);
+
+  return {
+    ...state,
+    goToSlide,
+    nextSlide,
+    prevSlide,
+    toggleAutoPlay,
+  };
+}

--- a/src/shared/hooks/useSwipeGesture.ts
+++ b/src/shared/hooks/useSwipeGesture.ts
@@ -1,0 +1,58 @@
+'use client';
+import { useCallback, useState } from 'react';
+
+import { TouchPosition, UseSwipeGestureProps } from '../types/carousel';
+
+export const useSwipeGesture = ({
+  onSwipeLeft,
+  onSwipeRight,
+  minSwipeDistance = 50,
+}: UseSwipeGestureProps) => {
+  const [touchStart, setTouchStart] = useState<TouchPosition | null>(null);
+  const [touchEnd, setTouchEnd] = useState<TouchPosition | null>(null);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    // 터치 이벤트가 있고 첫 번째 터치포인트가 존재하는지 확인
+    const touch = e.targetTouches?.[0];
+    if (!touch) return;
+
+    setTouchStart({ x: touch.clientX, y: touch.clientY });
+    setTouchEnd(null);
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    // 터치 이벤트가 있고 첫 번째 터치포인트가 존재하는지 확인
+    const touch = e.targetTouches?.[0];
+    if (!touch) return;
+
+    setTouchEnd({ x: touch.clientX, y: touch.clientY });
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    // 시작점과 끝점이 모두 존재하는지 확인
+    if (!touchStart || !touchEnd) return;
+
+    const distanceX = touchStart.x - touchEnd.x;
+    const distanceY = touchStart.y - touchEnd.y;
+    const isHorizontalSwipe = Math.abs(distanceX) > Math.abs(distanceY);
+
+    // 최소 스와이프 거리를 만족하는 수평 스와이프인지 확인
+    if (isHorizontalSwipe && Math.abs(distanceX) > minSwipeDistance) {
+      if (distanceX > 0) {
+        onSwipeLeft(); // 왼쪽으로 스와이프 (다음 슬라이드)
+      } else {
+        onSwipeRight(); // 오른쪽으로 스와이프 (이전 슬라이드)
+      }
+    }
+
+    // 상태 초기화
+    setTouchStart(null);
+    setTouchEnd(null);
+  }, [touchStart, touchEnd, minSwipeDistance, onSwipeLeft, onSwipeRight]);
+
+  return {
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  };
+};

--- a/src/shared/types/carousel.ts
+++ b/src/shared/types/carousel.ts
@@ -1,0 +1,64 @@
+// 기본 슬라이드 타입
+export interface Slide {
+  id: number;
+  title?: string;
+  description?: string;
+  image: string;
+  alt?: string;
+  link?: string;
+}
+
+// 캐러셀 컴포넌트 props
+export interface CarouselProps {
+  slides: Slide[];
+  interval?: number;
+  showCounter?: boolean;
+  className?: string;
+}
+
+// 캐러셀 상태
+export interface CarouselState {
+  currentSlide: number;
+  isTransitioning: boolean;
+  isAutoPlaying: boolean;
+}
+
+// 터치 위치
+export interface TouchPosition {
+  x: number;
+  y: number;
+}
+
+// useCarousel 훅 props
+export interface UseCarouselProps {
+  totalSlides: number;
+  onSlideChange?: (index: number) => void;
+}
+
+// useCarousel 훅의 액션 타입
+export type CarouselAction =
+  | { type: 'GO_TO'; index: number }
+  | { type: 'NEXT'; total: number }
+  | { type: 'PREV'; total: number }
+  | { type: 'END_TRANSITION' }
+  | { type: 'TOGGLE_AUTOPLAY' };
+
+// useSwipeGesture 훅 props
+export interface UseSwipeGestureProps {
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  minSwipeDistance?: number;
+}
+
+// 인디케이터 컴포넌트 props
+export interface IndicatorProps {
+  current: number;
+  total: number;
+  onIndicatorClick?: (index: number) => void;
+}
+
+// 카드 페이지네이션 컴포넌트 props
+export interface CardPaginationProps {
+  currentPage: number;
+  totalPage: number;
+}

--- a/src/shared/utils/carousel.ts
+++ b/src/shared/utils/carousel.ts
@@ -1,0 +1,18 @@
+import { Slide } from '@/shared/types/carousel';
+
+/**
+ * 이미지 URL 배열을 슬라이드 데이터로 변환
+ * @example
+ * ```typescript
+ * const { data } = useQuery('/api/images');
+ * const slides = createSlidesFromUrls(data.imageUrls);
+ * return <ImageCarousel slides={slides} />;
+ * ```
+ */
+export const createSlidesFromUrls = (imageUrls: string[]): Slide[] => {
+  return imageUrls.map((url, index) => ({
+    id: index + 1,
+    image: url,
+    alt: `이미지 ${index + 1}`,
+  }));
+};


### PR DESCRIPTION
## 📝 PR 내용 요약

- 이미지 캐러셀 컴포넌트 구현

### 주요 기능

- 자동 재생 (hover시 일시정지)
- 인디케이터 클릭할 경우 해당 index 이미지로 이동
- 모바일 스와이프 제스처
- 키보드 접근성 (화살표, Home/End)
- 반응형

### 사용법
```tsx
const slides = createSlidesFromUrls(data.imageUrls);
<ImageCarousel slides={slides} />
```

---

## 🧩 관련 이슈

- Close #101 

---

## 📸 스크린샷 (선택)

![화면 기록 2025-07-21 오전 4 02 44](https://github.com/user-attachments/assets/9e0a72db-f473-478a-93da-7b35e8765f24)


---

## 💬 참고 사항
- API 응답 변환 이유 (참고: createSlidesFromUrls 함수)
```tsx
// API 응답
{ imageUrls: ["url1", "url2", "url3"] }

// 캐러셀이 필요한 형태  
[{ id: 1, image: "url1", alt: "..." }, ...]
```
1. 확장성: 나중에 제목, 링크 등 쉽게 추가 가능
2. 타입 안전성
3. 향후 API 변경시에도 변환 함수만 수정하면 됩니다.
=> 유지보수성과 확장성에 장점이 있습니다.
---
