### PR TITLE
[feat] 알바토크 글쓰기 페이지 구현

### DIFF
--- a/src/app/(public)/addtalk/page.tsx
+++ b/src/app/(public)/addtalk/page.tsx
@@ -1,0 +1,6 @@
+import AddtalkClient from '@/features/addtalk/components/AddtalkClient';
+
+const AddtalkPage = () => {
+  return <AddtalkClient />;
+};
+export default AddtalkPage;

--- a/src/features/addtalk/components/AddtalkButtons.tsx
+++ b/src/features/addtalk/components/AddtalkButtons.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+
+import PrimaryButton from '@/shared/components/common/button/PrimaryButton';
+
+import { cn } from './../../../shared/lib/cn';
+
+const AddtalkButtons = ({ className }: { className?: string }) => {
+  return (
+    <div className={cn('flex flex-col gap-8 md:flex-row lg:gap-12', className)}>
+      <Link href="/albatalk">
+        <PrimaryButton
+          className="h-58 w-full md:h-46 md:w-108 lg:h-58 lg:w-180"
+          label="취소"
+          type="button"
+          variant="cancelSolid"
+        />
+      </Link>
+      <PrimaryButton
+        className="h-58 w-full md:h-46 md:w-108 lg:h-58 lg:w-180"
+        label="등록하기"
+        type="button"
+        variant="solid"
+      />
+    </div>
+  );
+};
+export default AddtalkButtons;

--- a/src/features/addtalk/components/AddtalkClient.tsx
+++ b/src/features/addtalk/components/AddtalkClient.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import AddtalkButtons from './AddtalkButtons';
+import AddtalkForm from './AddtalkForm';
+
+const AddtalkClient = () => {
+  return (
+    <div className="flex flex-col gap-16 px-24 py-16 md:px-72 md:py-24 lg:gap-24 lg:px-220 lg:py-40">
+      <header className="flex items-center justify-between border-b border-line-200 py-16 md:px-24 lg:py-34">
+        <h1 className="text-2lg font-semibold text-black-400 md:text-xl lg:text-3xl">
+          글쓰기
+        </h1>
+        <AddtalkButtons className="hidden md:flex" />
+      </header>
+      <AddtalkForm />
+      <AddtalkButtons className="md:hidden" />
+    </div>
+  );
+};
+export default AddtalkClient;

--- a/src/features/addtalk/components/AddtalkForm.tsx
+++ b/src/features/addtalk/components/AddtalkForm.tsx
@@ -1,0 +1,32 @@
+import Input from '@/shared/components/common/input/Input';
+import Label from '@/shared/components/common/input/Label';
+import Textarea from '@/shared/components/common/input/Textarea';
+import UploadSingleImage from '@/shared/components/common/uploadImage/UploadSingleImage';
+
+const AddtalkForm = () => {
+  return (
+    <div className="flex flex-col gap-24 py-16 md:px-24 lg:gap-40 lg:py-48">
+      <section className="flex flex-col gap-16">
+        <Label isRequired htmlFor="title">
+          제목
+        </Label>
+        <Input id="title" placeholder="제목을 입력해주세요." />
+      </section>
+      <section className="flex flex-col gap-16">
+        <Label isRequired htmlFor="content">
+          내용
+        </Label>
+        <Textarea
+          className="h-180 md:h-200 lg:h-240"
+          id="content"
+          placeholder="내용을 입력해주세요."
+        />
+      </section>
+      <section className="flex flex-col gap-16">
+        <Label htmlFor="imageUrl">이미지</Label>
+        <UploadSingleImage id="imageUrl" onImageChange={() => {}} />
+      </section>
+    </div>
+  );
+};
+export default AddtalkForm;

--- a/src/shared/components/common/uploadImage/UploadSingleImage.tsx
+++ b/src/shared/components/common/uploadImage/UploadSingleImage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import InputFileImage from '@common/input/InputFileImage';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
@@ -8,6 +10,10 @@ interface UploadSingleImageProps {
    * 선택된 단일 `File` 을 인자로 받습니다.
    */
   onImageChange: (file: File) => void;
+  /**
+   * input 요소의 고유 ID입니다. `label`의 `htmlFor` 속성과 연결하는 데 사용될 수 있습니다.
+   */
+  id?: string;
 }
 
 /**
@@ -15,7 +21,7 @@ interface UploadSingleImageProps {
  * 사용자가 이미지를 선택하면 해당 이미지를 미리보기로 보여주고,
  * 선택된 `File` 을 `onImageChange` 콜백을 통해 상위 컴포넌트로 전달합니다.
  */
-const UploadSingleImage = ({ onImageChange }: UploadSingleImageProps) => {
+const UploadSingleImage = ({ onImageChange, id }: UploadSingleImageProps) => {
   const [previewImage, setPreviewImage] = useState<string | null>(null);
   useEffect(() => {
     return () => {
@@ -56,6 +62,7 @@ const UploadSingleImage = ({ onImageChange }: UploadSingleImageProps) => {
 
       <InputFileImage
         className="absolute inset-0 cursor-pointer"
+        id={id}
         onImageChange={handleImageChange}
       />
     </div>

--- a/src/shared/components/common/uploadImage/UploadSingleImage.tsx
+++ b/src/shared/components/common/uploadImage/UploadSingleImage.tsx
@@ -36,7 +36,7 @@ const UploadSingleImage = ({ onImageChange, id }: UploadSingleImageProps) => {
     onImageChange(files[0]);
   };
   return (
-    <div className="relative flex size-160 flex-col items-center justify-center gap-8 rounded-lg bg-background-200 lg:size-240">
+    <div className="relative flex size-160 flex-col items-center justify-center gap-8 overflow-hidden rounded-lg bg-background-200 lg:size-240">
       {previewImage ? (
         <Image
           fill


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 알바토크 글쓰기 페이지의 ui를 구현했습니다.
- 단일 이미지 업로드 컴포넌트에 id값을 받을 수 있도록 수정했습니다

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #106

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
<img width="1215" height="922" alt="de" src="https://github.com/user-attachments/assets/bbcaee1f-c890-4ca0-8e82-2ecc048b9405" />
<img width="707" height="848" alt="ta" src="https://github.com/user-attachments/assets/c012514e-f01d-420e-a463-e21dabc3f644" />
<img width="509" height="848" alt="mo" src="https://github.com/user-attachments/assets/97bacd1d-1a25-4280-b17c-bccf30ce0654" />

(이미지 첨부)

---

## 💬 참고 사항
primary 버튼의 기본 글자 색상이 조금 어두운 것 같습니다. 제 기억으로는 primary버튼이 만들어진 후에 gray-50의 색상값이 변경 되어 이렇게 된 거 같습니다. addform 만들 때는 classname을 주어 글자 색을 변경했었는데 primary 버튼의 기본 글자 색상을 수정하는 거 어떨까요?

