### PR TITLE
[feat] 알바폼 지원내역 상세보기 컴포넌트 구현

### DIFF
--- a/src/app/(owner)/application/[applicationId]/page.tsx
+++ b/src/app/(owner)/application/[applicationId]/page.tsx
@@ -1,0 +1,9 @@
+import ApplicationDetail from '@/features/apply/components/apply-detail';
+import mockApplyDetail from '@/features/apply/mocks/mockApplyDetail';
+
+const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const { id } = await params;
+  return <ApplicationDetail applyResponse={mockApplyDetail} />;
+};
+
+export default Page;

--- a/src/app/(owner)/application/layout.tsx
+++ b/src/app/(owner)/application/layout.tsx
@@ -1,0 +1,13 @@
+import InnerContainer from '@/shared/components/container/InnerContainer';
+
+const AlbaTalkLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div>
+      <main>
+        <InnerContainer>{children}</InnerContainer>
+      </main>
+    </div>
+  );
+};
+
+export default AlbaTalkLayout;

--- a/src/app/(owner)/application/page.tsx
+++ b/src/app/(owner)/application/page.tsx
@@ -1,0 +1,7 @@
+import ApplicationDetail from '@/features/apply/components/apply-detail';
+
+const ApplicationPage = () => {
+  return <ApplicationDetail />;
+};
+
+export default ApplicationPage;

--- a/src/app/(worker)/myapply/[formId]/page.tsx
+++ b/src/app/(worker)/myapply/[formId]/page.tsx
@@ -1,0 +1,9 @@
+import ApplicationDetail from '@/features/apply/components/apply-detail';
+import mockApplyDetail from '@/features/apply/mocks/mockApplyDetail';
+
+const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const { id } = await params;
+  return <ApplicationDetail applyResponse={mockApplyDetail} />;
+};
+
+export default Page;

--- a/src/app/(worker)/myapply/layout.tsx
+++ b/src/app/(worker)/myapply/layout.tsx
@@ -1,0 +1,13 @@
+import InnerContainer from '@/shared/components/container/InnerContainer';
+
+const MyApplyLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div>
+      <main>
+        <InnerContainer>{children}</InnerContainer>
+      </main>
+    </div>
+  );
+};
+
+export default MyApplyLayout;

--- a/src/app/(worker)/myapply/page.tsx
+++ b/src/app/(worker)/myapply/page.tsx
@@ -1,0 +1,7 @@
+import ApplicationDetail from '@/features/apply/components/apply-detail';
+
+const MyApplyPage = () => {
+  return <ApplicationDetail />;
+};
+
+export default MyApplyPage;

--- a/src/features/apply/components/apply-detail/ApplyProfile.tsx
+++ b/src/features/apply/components/apply-detail/ApplyProfile.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { ApplyResponse } from '../../types/apply';
+
+interface ApplyProfileProps {
+  data: ApplyResponse;
+}
+
+const ApplyProfile = ({ data }: ApplyProfileProps) => {
+  const { name, phoneNumber, experienceMonths, resumeName, introduction } =
+    data;
+
+  const getExperienceText = (months: number) => {
+    if (months === 0) return '신입';
+    if (months < 12) return `${months}개월`;
+    const years = Math.floor(months / 12);
+    const remainingMonths = months % 12;
+    return remainingMonths > 0
+      ? `${years}년 ${remainingMonths}개월`
+      : `${years}년`;
+  };
+
+  return (
+    <div>
+      <h2 className="my-16 text-2lg font-semibold">제출 내용</h2>
+      <div className="space-y-6 lg:grid lg:grid-cols-2 lg:gap-12 lg:space-y-0">
+        <div className="space-y-6">
+          {/* 이름 */}
+          <div className="flex items-center justify-between border-b border-gray-200 py-14">
+            <span className="text-gray-500 dark:text-gray-400">이름</span>
+            <span className="font-medium">{name}</span>
+          </div>
+
+          {/* 연락처 */}
+          <div className="flex items-center justify-between border-b border-gray-200 py-14">
+            <span className="text-gray-400">연락처</span>
+            <span className="font-medium">{phoneNumber}</span>
+          </div>
+
+          {/* 경력 */}
+          <div className="flex items-center justify-between border-b border-gray-200 py-14">
+            <span className="text-gray-400">경력</span>
+            <span className="font-medium">
+              {getExperienceText(experienceMonths)}
+            </span>
+          </div>
+
+          {/* 이력서 */}
+          <div className="py-4">
+            <div className="mb-4 py-14 text-gray-400">이력서</div>
+            <div className="flex items-center justify-between rounded-lg bg-gray-50 p-14">
+              <span className="text-gray-700">
+                {resumeName || '이력서 없음'}
+              </span>
+            </div>
+          </div>
+
+          {/* 자기소개 */}
+          <div className="py-4">
+            <div className="mb-4 py-14 text-gray-400">자기소개</div>
+            <div className="rounded-lg bg-gray-50 p-14">
+              <p className="text-md leading-relaxed whitespace-pre-wrap text-black-400">
+                {introduction || '자기소개가 작성되지 않았습니다.'}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ApplyProfile;

--- a/src/features/apply/components/apply-detail/ApplyState.tsx
+++ b/src/features/apply/components/apply-detail/ApplyState.tsx
@@ -1,0 +1,78 @@
+import { differenceInCalendarDays, format } from 'date-fns';
+import React from 'react';
+
+import useViewport from '@/shared/hooks/useViewport';
+import { cn } from '@/shared/lib/cn';
+
+import { ApplyStatus } from '../../types/apply';
+
+interface ApplyStateProps {
+  status: ApplyStatus;
+  createdAt: string;
+  recruitmentEndDate: string;
+}
+
+const ApplyState = ({
+  status,
+  createdAt,
+  recruitmentEndDate,
+}: ApplyStateProps) => {
+  const { isDesktop } = useViewport();
+
+  // D-Day 계산
+  const today = new Date();
+  const recruitmentEnd = new Date(recruitmentEndDate);
+  const daysLeft = differenceInCalendarDays(recruitmentEnd, today);
+  const dDayString = daysLeft >= 0 ? `D-${daysLeft}` : '모집 마감';
+
+  // 지원일시 포맷팅
+  const applicationDate = format(new Date(createdAt), 'yyyy.MM.dd HH:mm');
+
+  // 상태별 정보
+  const getStatusInfo = (status: ApplyStatus) => {
+    switch (status) {
+      case 'INTERVIEW_PENDING':
+        return { text: '면접 대기' };
+      case 'INTERVIEW_COMPLETED':
+        return { text: '면접 완료' };
+      case 'HIRED':
+        return { text: '채용 완료' };
+      case 'REJECTED':
+        return { text: '거절' };
+      default:
+        return { text: '알 수 없음' };
+    }
+  };
+
+  const statusInfo = getStatusInfo(status);
+
+  return (
+    <div className="lg:rounded-lg lg:bg-gray-25 lg:p-24">
+      {/* 지원 일시 */}
+      <div className="flex items-center justify-between border-b border-gray-200 py-14">
+        <div className="flex items-center gap-4">
+          <span className="text-gray-400">지원 일시</span>
+          {isDesktop && (
+            <span
+              className={cn(
+                'ml-2 font-semibold',
+                dDayString === '모집 마감' ? 'Text-error' : 'text-mint-400'
+              )}
+            >
+              {dDayString}
+            </span>
+          )}
+        </div>
+        <span>{applicationDate}</span>
+      </div>
+
+      {/* 진행 상태 */}
+      <div className="flex items-center justify-between border-b border-gray-200 py-14 lg:border-b-0">
+        <span className="text-gray-400">진행 상태</span>
+        <span>{statusInfo.text}</span>
+      </div>
+    </div>
+  );
+};
+
+export default ApplyState;

--- a/src/features/apply/components/apply-detail/index.tsx
+++ b/src/features/apply/components/apply-detail/index.tsx
@@ -1,0 +1,78 @@
+'use client';
+import { useParams, usePathname } from 'next/navigation';
+
+import { albaMockData } from '@/features/alba/mocks/mockData';
+import AlbaDescription from '@/shared/components/alba/AlbaDescription';
+import AlbaDetail from '@/shared/components/alba/AlbaDetail';
+import ImageCarousel from '@/shared/components/ui/ImageCarousel';
+import { Slide } from '@/shared/types/carousel';
+import { createSlidesFromUrls } from '@/shared/utils/carousel';
+
+import { ApplyResponse } from '../../types/apply';
+import ApplyProfile from './ApplyProfile';
+import ApplyState from './ApplyState';
+
+interface ApplyDetailProps {
+  applyResponse?: ApplyResponse;
+  images?: string[];
+}
+
+const ApplyDetail = ({
+  applyResponse,
+  images = [
+    '/images/landing/albaform-clock.png',
+    '/images/landing/apply-girl.png',
+    '/images/landing/anywhere-application.png',
+  ],
+}: ApplyDetailProps) => {
+  const sampleSlides: Slide[] = createSlidesFromUrls(images);
+  const params = useParams();
+  const pathname = usePathname(); // 또는 router.pathname
+
+  // URL 패턴으로 구분
+  const isOwnerView = pathname.includes('/application/'); // 사장님 뷰
+
+  const itemId = isOwnerView
+    ? Number(params.applicationId)
+    : Number(params.formId);
+
+  const item = albaMockData.find(alba => alba.id === Number(itemId));
+
+  if (!item) {
+    return (
+      <div className="py-40 text-center text-red-500">
+        {itemId}
+        해당 알바 정보를 찾을 수 없습니다.
+      </div>
+    );
+  }
+
+  if (!applyResponse) {
+    return <div>지원서 정보가 없습니다.</div>;
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-375 min-w-320 flex-col gap-40 py-40 text-sm lg:max-w-7xl lg:text-lg">
+      <ImageCarousel showCounter interval={4000} slides={sampleSlides} />
+
+      <div className="space-y-40 lg:grid lg:grid-cols-2 lg:gap-150 lg:space-y-0">
+        <div className="space-y-40">
+          <AlbaDetail item={item} />
+          <AlbaDescription description={item.description} />
+        </div>
+        {/* 지원서 상태 */}
+        <div>
+          <ApplyState
+            createdAt={applyResponse.createdAt}
+            recruitmentEndDate={item.recruitmentEndDate}
+            status={applyResponse.status}
+          />
+        </div>
+      </div>
+      <div className="border-4 border-line-100" />
+      <ApplyProfile data={applyResponse} />
+    </div>
+  );
+};
+
+export default ApplyDetail;

--- a/src/features/apply/mocks/mockApplyDetail.ts
+++ b/src/features/apply/mocks/mockApplyDetail.ts
@@ -1,0 +1,18 @@
+import { ApplyResponse } from '../types/apply';
+
+export const mockApplyDetail: ApplyResponse = {
+  id: 341,
+  name: '김철이',
+  phoneNumber: '01012341234',
+  experienceMonths: 7,
+  resumeId: 242,
+  resumeName: '김철이_이력서.pdf',
+  introduction:
+    '안녕하세요. 김철이입니다. 스터디카페와 가까운 곳에 거주중이고, 타 스터디카페 근무 경험 있습니다.(****스터디 카페 6개월 근무) 현재 휴학 중으로 근무 빠지지 않고 할 수 있습니다. 감사합니다.!',
+  status: 'INTERVIEW_PENDING',
+  createdAt: '2025-07-21T14:56:15.791Z',
+  updatedAt: '2025-07-21T14:56:15.791Z',
+  applicantId: 446,
+};
+
+export default mockApplyDetail;

--- a/src/features/apply/types/apply.ts
+++ b/src/features/apply/types/apply.ts
@@ -1,0 +1,58 @@
+// 기본 지원서 데이터 타입
+export interface ApplyData {
+  password: string;
+  introduction: string;
+  resumeData: string;
+  resumeId: number;
+  experienceMonths: number;
+  phoneNumber: string;
+  name: string;
+}
+
+// 지원서 생성 요청 타입
+export interface CreateApplyRequest {
+  formId: number;
+  ApplyData: ApplyData;
+}
+
+// 지원서 응답 타입 (생성 후 반환되는 데이터)
+export interface ApplyResponse {
+  id: number;
+  name: string;
+  phoneNumber: string;
+  experienceMonths: number;
+  resumeId: number;
+  resumeName: string;
+  introduction: string;
+  status: ApplyStatus;
+  createdAt: string;
+  updatedAt: string;
+  applicantId: number;
+}
+
+// 지원서 상태 타입
+export type ApplyStatus =
+  | 'INTERVIEW_PENDING'
+  | 'REJECTED'
+  | 'INTERVIEW_COMPLETED'
+  | 'HIRED';
+
+// 지원서 상태 업데이트 요청 타입
+export interface UpdateApplyStatusRequest {
+  status: ApplyStatus;
+}
+
+// 지원서 상태 업데이트 응답 타입
+export interface UpdateApplyStatusResponse {
+  applicantId: number;
+  updatedAt: string;
+  createdAt: string;
+  status: ApplyStatus;
+  introduction: string;
+  resumeName: string;
+  resumeId: number;
+  experienceMonths: number;
+  phoneNumber: string;
+  name: string;
+  id: number;
+}

--- a/src/shared/components/ui/ImageCarousel.tsx
+++ b/src/shared/components/ui/ImageCarousel.tsx
@@ -120,7 +120,7 @@ const ImageCarousel: React.FC<CarouselProps> = ({
       aria-label="이미지 캐러셀"
       aria-live="polite"
       className={cn(
-        'relative mx-auto h-260 w-full overflow-hidden rounded-2xl bg-white shadow-2xl lg:h-562',
+        'relative mx-auto h-260 w-full overflow-hidden bg-white lg:h-562',
         className
       )}
       role="region"


### PR DESCRIPTION
## 📝 PR 내용 요약

- 지원내역 상세 페이지 화면 UI 구현
- 테스트 경로
  - http://localhost:3000/application/452 (사장님)
  - http://localhost:3000/myapply/452 (지원자)
---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #105 

---

## 📸 스크린샷 (선택)

![화면 기록 2025-07-22 오전 7 14 43](https://github.com/user-attachments/assets/c4990fce-82a0-43ed-9466-c9304bb6bb35)


---

## 📌 후속 작업
- 모달창 구현
- 사장님의 경우 툴팁 반영
---
