### PR TITLE
[fix] body, input 계열 공통 컴포넌트 다크모드 스타일 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,6 +30,7 @@
   --color-mint-100: hsl(171, 86%, 68%);
   --color-mint-200: hsl(171, 86%, 58%);
   --color-mint-300: hsl(171, 86%, 48%);
+  --color-mint-350: hsl(171, 86%, 43%);
   --color-mint-400: hsl(171, 86%, 38%);
 
   --text-xs: 0.75rem;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
         content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"
         name="viewport"
       />
-      <body className={pretendard.className}>
+      <body className={`${pretendard.className} dark:bg-gray-900`}>
         <ThemeProvider enableSystem attribute="class" defaultTheme="system">
           <Providers>{children}</Providers>
           <ModalManager />

--- a/src/shared/components/common/input/Label.tsx
+++ b/src/shared/components/common/input/Label.tsx
@@ -24,13 +24,19 @@ interface LabelProps
 const Label = ({ children, isRequired, className, ...props }: LabelProps) => {
   return (
     <label
-      className={cn('text-md font-medium text-black-400 lg:text-xl', className)}
+      className={cn(
+        'text-md font-medium text-black-400 lg:text-xl dark:text-gray-100',
+        className
+      )}
       {...props}
     >
       {children}
       {isRequired && (
         <>
-          <span aria-hidden="true" className="ml-4 text-mint-300">
+          <span
+            aria-hidden="true"
+            className="ml-4 text-mint-300 dark:text-mint-350"
+          >
             *
           </span>
           <span className="sr-only">필수</span>

--- a/src/shared/components/common/input/inputStyles.ts
+++ b/src/shared/components/common/input/inputStyles.ts
@@ -10,7 +10,7 @@ export const inputStyle = {
 
 export const inputVariants = {
   solid:
-    'bg-background-200 hover:bg-background-300 dark:bg-gray-700 dark:hover:bg-gray-800',
+    'bg-background-200 hover:bg-background-300 dark:bg-gray-800 dark:hover:bg-gray-700',
   outlined:
     'border border-gray-200 hover:border-gray-400 focus:border-mint-300',
 };

--- a/src/shared/components/common/input/inputStyles.ts
+++ b/src/shared/components/common/input/inputStyles.ts
@@ -1,7 +1,7 @@
 export const inputStyle = {
   default: `
-    text-lg font-normal text-black-400 placeholder:text-gray-400 lg:text-xl
-    rounded-lg caret-mint-300 outline-mint-300 focus:outline
+    text-lg font-normal text-black-400 placeholder:text-gray-400 lg:text-xl dark:text-gray-100
+    rounded-lg caret-mint-300 outline-mint-300 focus:outline dark:caret-mint-350 dark:outline-mint-350
     transition duration-200
   `,
   invalid:
@@ -9,7 +9,8 @@ export const inputStyle = {
 };
 
 export const inputVariants = {
-  solid: 'bg-background-200 hover:bg-background-300',
+  solid:
+    'bg-background-200 hover:bg-background-300 dark:bg-gray-700 dark:hover:bg-gray-800',
   outlined:
     'border border-gray-200 hover:border-gray-400 focus:border-mint-300',
 };


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- body, input, textarea, label 컴포넌트의 다크모드 스타일을 추가합니다.
---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close # 112

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.
<img width="470" height="373" alt="기존" src="https://github.com/user-attachments/assets/7351c092-a62c-45e6-aa64-c6ca4a87a781" />
<img width="506" height="376" alt="new" src="https://github.com/user-attachments/assets/f5813acd-0036-43e5-8b6c-c1ebb96685bc" />

(이미지 첨부)

---

## 💬 참고 사항


