### PR TITLE
[fix] PrimaryButton 및 MyScrapCard 스타일 수정

### DIFF
--- a/src/features/mypage/components/MixedSection.tsx
+++ b/src/features/mypage/components/MixedSection.tsx
@@ -27,9 +27,9 @@ const MixedSection = ({ cardInfo, type }: MixedSectionProps) => {
 
   const firstItem = cardInfo[0];
   const scrapWrapStyle =
-    'grid-rows-auto relative grid grid-cols-1 place-items-center items-center gap-y-32 md:gap-y-48 lg:flex-row lg:flex-wrap lg:gap-x-25 lg:gap-y-45 xl:grid-cols-3';
+    'grid-rows-auto relative grid grid-cols-1 gap-y-32 md:gap-y-48 lg:gap-x-25 lg:gap-y-45 lg:grid-cols-2 xl:grid-cols-3';
   const postCommentWrapStyle =
-    'grid-rows-auto grid grid-cols-1 items-center gap-y-16 lg:grid-cols-2 lg:flex-row lg:flex-wrap lg:gap-x-25 lg:gap-y-45 xl:grid-cols-3';
+    'grid-rows-auto grid grid-cols-1 items-center gap-y-16 lg:grid-cols-2 lg:gap-x-25 lg:gap-y-45 xl:grid-cols-3';
 
   // Card 컴포넌트 Wrap 스타일 결정 함수
   const getCardWrapStyle = (item: CardInfoItem) => {
@@ -45,15 +45,15 @@ const MixedSection = ({ cardInfo, type }: MixedSectionProps) => {
       case 'comment':
         return [
           {
-            value: '수정하기',
-            clickEvent: () => router.push(`/albatalks/${id}`),
+            label: '수정하기',
+            onClick: () => router.push(`/albatalks/${id}`),
           },
-          { value: '삭제하기', clickEvent: () => router.push(`/`) },
+          { label: '삭제하기', onClick: () => router.push(`/`) },
         ];
       case 'scrap':
         return [
-          { value: '지원하기', clickEvent: () => router.push(`/apply/${id}`) },
-          { value: '스크랩 취소', clickEvent: () => router.push(`/`) },
+          { label: '지원하기', onClick: () => router.push(`/apply/${id}`) },
+          { label: '스크랩 취소', onClick: () => router.push(`/`) },
         ];
     }
   };

--- a/src/features/mypage/components/MyCommentCard.tsx
+++ b/src/features/mypage/components/MyCommentCard.tsx
@@ -3,14 +3,15 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
-import { CommentCardItem, DropdownValue } from '@/shared/types/mypage';
+import { CommentCardItem } from '@/shared/types/mypage';
 
+import { DropdownOption } from '../../../shared/components/common/list/AlbaCardItem';
 import DateFormatter from './DateFormatter';
 import MyPageDropDown from './MyPageDropDown';
 
 interface MyCommentCardProps {
   cardContent: CommentCardItem;
-  dropdownItem: DropdownValue[];
+  dropdownItem: DropdownOption[];
 }
 
 const MyCommentCard = ({ cardContent, dropdownItem }: MyCommentCardProps) => {

--- a/src/features/mypage/components/MyCommentCard.tsx
+++ b/src/features/mypage/components/MyCommentCard.tsx
@@ -3,9 +3,9 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
+import { DropdownOption } from '@/shared/components/common/list/AlbaCardItem';
 import { CommentCardItem } from '@/shared/types/mypage';
 
-import { DropdownOption } from '../../../shared/components/common/list/AlbaCardItem';
 import DateFormatter from './DateFormatter';
 import MyPageDropDown from './MyPageDropDown';
 

--- a/src/features/mypage/components/MyPageDropDown.tsx
+++ b/src/features/mypage/components/MyPageDropDown.tsx
@@ -4,8 +4,8 @@ import Dropdown from '@/shared/components/ui/Dropdown';
 import { cn } from '@/shared/lib/cn';
 
 interface MyPageDropdownValueProps {
-  value: string;
-  clickEvent: () => void;
+  label: string;
+  onClick: () => void;
 }
 
 interface MyPageDropdownProps {
@@ -33,15 +33,15 @@ const MyPageDropDown = ({ items, className }: MyPageDropdownProps) => {
           {items.map(item => {
             return (
               <li
-                key={item.value}
+                key={item.label}
                 className="inline-flex w-full items-center justify-center"
               >
                 <button
                   className="w-90 rounded-lg py-4 text-xs text-gray-400 hover:bg-mint-50 hover:font-semibold hover:text-black"
                   type="button"
-                  onClick={() => item.clickEvent()}
+                  onClick={() => item.onClick()}
                 >
-                  {item.value}
+                  {item.label}
                 </button>
               </li>
             );

--- a/src/features/mypage/components/MyPostCard.tsx
+++ b/src/features/mypage/components/MyPostCard.tsx
@@ -3,14 +3,15 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
-import { DropdownValue, PostCardItem } from '@/shared/types/mypage';
+import { PostCardItem } from '@/shared/types/mypage';
 
+import { DropdownOption } from '../../../shared/components/common/list/AlbaCardItem';
 import DateFormatter from './DateFormatter';
 import MyPageDropDown from './MyPageDropDown';
 
 interface MyPostCardProps {
   cardContent: PostCardItem;
-  dropdownItem: DropdownValue[];
+  dropdownItem: DropdownOption[];
   key?: string | number;
 }
 

--- a/src/features/mypage/components/MyPostCard.tsx
+++ b/src/features/mypage/components/MyPostCard.tsx
@@ -3,9 +3,9 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
+import { DropdownOption } from '@/shared/components/common/list/AlbaCardItem';
 import { PostCardItem } from '@/shared/types/mypage';
 
-import { DropdownOption } from '../../../shared/components/common/list/AlbaCardItem';
 import DateFormatter from './DateFormatter';
 import MyPageDropDown from './MyPageDropDown';
 

--- a/src/features/mypage/components/MyScrapCard.tsx
+++ b/src/features/mypage/components/MyScrapCard.tsx
@@ -1,114 +1,32 @@
 'use client';
 
-import { differenceInCalendarDays, isAfter } from 'date-fns';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
-import Chip from '@/shared/components/common/chip/Chip';
 import PrivateWrapper from '@/shared/components/common/PrivateWrapper';
-import { cn } from '@/shared/lib/cn';
-import { DropdownValue, ScrapCardItem } from '@/shared/types/mypage';
+import { ScrapCardItem } from '@/shared/types/mypage';
 
-import DateFormatter from './DateFormatter';
-import MyPageDropDown from './MyPageDropDown';
+import AlbaCardItem from '../../../shared/components/common/list/AlbaCardItem';
+import { DropdownOption } from '../../../shared/components/common/list/AlbaCardItem';
 
 interface MyScrapCardProps {
   cardContent: ScrapCardItem;
-  dropdownItem: DropdownValue[];
+  dropdownItem: DropdownOption[];
 }
 
 const MyScrapCard = ({ cardContent, dropdownItem }: MyScrapCardProps) => {
   const router = useRouter();
 
-  const imgSrc = cardContent.imageUrls[0]
-    ? cardContent?.imageUrls[0]
-    : '/images/logo.svg';
-  const isRecruiting = isAfter(cardContent.recruitmentEndDate, new Date());
-  const dDay = differenceInCalendarDays(
-    cardContent.recruitmentEndDate,
-    new Date()
-  );
-
-  const dDayFormat = () => {
-    if (dDay < 0) {
-      return '마감완료';
-    }
-
-    return `마감 D-${dDay}`;
-  };
-
-  const handleCardClick = (e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    const isInteractiveElement =
-      target.closest('button') ||
-      target.closest('[role="button"]') ||
-      target.closest('[role="menu"]');
-
-    if (isInteractiveElement) {
-      return;
-    }
-
+  const handleCardClick = () => {
     router.push(`/apply/${cardContent.id}`);
   };
 
   return (
-    <PrivateWrapper
-      className="w-327 md:w-full md:max-w-476"
-      isPrivate={cardContent.isPublic}
-    >
-      <div
-        key={cardContent.id}
-        className="flex h-390 w-327 flex-col items-start justify-start gap-24 rounded-2xl p-3 transition-all duration-300 hover:scale-[1.01] hover:shadow-lg md:h-full md:w-full md:max-w-476 lg:w-full lg:max-w-476"
+    <PrivateWrapper isPrivate={cardContent.isPublic}>
+      <AlbaCardItem
+        dropdownOptions={dropdownItem}
+        item={cardContent}
         onClick={handleCardClick}
-      >
-        {/* Card top */}
-        <section className="relative flex h-208 w-full items-center justify-between rounded-2xl shadow-md md:h-304">
-          <Image fill alt="공고 이미지" src={imgSrc} />
-        </section>
-        {/* Card body */}
-        <section className="mb-32 flex w-full flex-col justify-start">
-          <div className="mb-16 inline-flex w-full items-center md:mb-24">
-            <div className="mr-8 inline-flex items-center gap-8">
-              <Chip
-                active
-                label={cardContent.isPublic ? '비공개' : '공개'}
-                variant="filled"
-              />
-              <Chip
-                active
-                label={isRecruiting ? '모집중' : '모집마감'}
-                variant="filled"
-              />
-            </div>
-            <div className="Text-gray inline-flex flex-1 items-center text-md lg:text-lg">
-              <span>{DateFormatter(cardContent.recruitmentStartDate)}</span> ~
-              <span>{DateFormatter(cardContent.recruitmentEndDate)}</span>
-            </div>
-            <div className="self-end">
-              <MyPageDropDown items={dropdownItem} />
-            </div>
-          </div>
-          <h3 className="Text-black text-lg font-medium">
-            {cardContent.title}
-          </h3>
-        </section>
-        {/* Card footer */}
-        <section className="relative bottom-0 flex w-full items-center justify-between rounded-2xl border border-line-100 bg-gray-25 px-43 py-12 text-xs text-black-200 md:text-lg dark:bg-gray-50">
-          <span className="w-1/3 text-center">
-            지원자 {cardContent.applyCount}명
-          </span>
-          <span className="inline-flex h-16 w-1 bg-line-200" />
-          <span className="w-1/3 text-center">
-            스크랩 {cardContent.scrapCount}명
-          </span>
-          <span className="inline-flex h-16 w-1 bg-line-200" />
-          <span
-            className={cn('w-1/3 text-center', dDay <= 5 && 'text-red-500')}
-          >
-            {dDayFormat()}
-          </span>
-        </section>
-      </div>
+      />
     </PrivateWrapper>
   );
 };

--- a/src/shared/components/common/button/PrimaryButton.tsx
+++ b/src/shared/components/common/button/PrimaryButton.tsx
@@ -80,10 +80,10 @@ const PrimaryButton = ({
 
   // variant별 스타일 정의
   const solidStyles =
-    'bg-mint-300 hover:bg-mint-400 text-gray-50 disabled:bg-gray-100 disabled:hover:bg-gray-100';
+    'bg-mint-300 hover:bg-mint-400 text-gray-25 disabled:bg-gray-100 disabled:hover:bg-gray-100';
   const outlineStyles =
     'border border-mint-300 hover:border-mint-400 text-mint-300 hover:text-mint-400 bg-transparent disabled:border-gray-100 disabled:hover:border-gray-100 disabled:text-gray-100 disabled:hover:text-gray-100';
-  const cancelSolidStyles = 'bg-gray-100 text-gray-50';
+  const cancelSolidStyles = 'bg-gray-100 text-gray-25';
   const cancelOutlineStyles =
     'border border-gray-100 text-gray-100  bg-transparent';
 


### PR DESCRIPTION
## 📝 PR 내용 요약

- PrimaryButton의 텍스트 색상을 text-gray-50에서 text-gray-25로 변경
- MyScrapCard 컴포넌트 수정 및 props 타입 변경

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #115 

---

## 📸 스크린샷 (선택)

<img width="162" height="104" alt="image" src="https://github.com/user-attachments/assets/d81e3c22-3678-45b1-a8ca-3637122f0deb" />


<img width="1032" height="708" alt="image" src="https://github.com/user-attachments/assets/76304a49-66a2-473c-82d6-46a304ef4305" />

---

## 💬 참고 사항

---
