### PR TITLE
[feat] 지원내역 상세 페이지 모달, 툴팁 반영

### DIFF
--- a/src/app/test/yujin/page.tsx
+++ b/src/app/test/yujin/page.tsx
@@ -36,7 +36,7 @@ const TestPage = () => {
 
       <div className="flex justify-center">
         <Tooltip
-          content={({ close }) => (
+          content={
             <div className="flex items-center gap-2">
               <div className="relative h-24 w-24 md:h-30 md:w-30">
                 <Image fill alt="info" src="/icons/info.svg" />
@@ -52,7 +52,7 @@ const TestPage = () => {
                 <Image fill alt="닫기 버튼" src="/icons/x-thin.svg" />
               </button>
             </div>
-          )}
+          }
         >
           <Image
             alt="수정 아이콘"

--- a/src/features/apply/components/apply-detail/ApplyProfile.tsx
+++ b/src/features/apply/components/apply-detail/ApplyProfile.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import { getExperienceLabel } from '@/shared/utils/application';
+import { formatPhoneNumber } from '@/shared/utils/format';
+
 import { ApplyResponse } from '../../types/apply';
 
 interface ApplyProfileProps {
@@ -9,16 +12,6 @@ interface ApplyProfileProps {
 const ApplyProfile = ({ data }: ApplyProfileProps) => {
   const { name, phoneNumber, experienceMonths, resumeName, introduction } =
     data;
-
-  const getExperienceText = (months: number) => {
-    if (months === 0) return '신입';
-    if (months < 12) return `${months}개월`;
-    const years = Math.floor(months / 12);
-    const remainingMonths = months % 12;
-    return remainingMonths > 0
-      ? `${years}년 ${remainingMonths}개월`
-      : `${years}년`;
-  };
 
   return (
     <div>
@@ -34,14 +27,16 @@ const ApplyProfile = ({ data }: ApplyProfileProps) => {
           {/* 연락처 */}
           <div className="flex items-center justify-between border-b border-gray-200 py-14">
             <span className="text-gray-400">연락처</span>
-            <span className="font-medium">{phoneNumber}</span>
+            <span className="font-medium">
+              {formatPhoneNumber(phoneNumber, true)}
+            </span>
           </div>
 
           {/* 경력 */}
           <div className="flex items-center justify-between border-b border-gray-200 py-14">
             <span className="text-gray-400">경력</span>
             <span className="font-medium">
-              {getExperienceText(experienceMonths)}
+              {getExperienceLabel(experienceMonths)}
             </span>
           </div>
 

--- a/src/features/apply/components/apply-detail/ApplyState.tsx
+++ b/src/features/apply/components/apply-detail/ApplyState.tsx
@@ -33,7 +33,7 @@ const ApplyState = ({
   const { openModal } = useModalStore();
 
   const handleApplyStateModal = () => {
-    openModal(<ApplyStateModal />);
+    openModal(<ApplyStateModal currentStatus={status} />);
   };
 
   return (

--- a/src/features/apply/components/apply-detail/ApplyState.tsx
+++ b/src/features/apply/components/apply-detail/ApplyState.tsx
@@ -1,10 +1,15 @@
 import { differenceInCalendarDays, format } from 'date-fns';
+import Image from 'next/image';
 import React from 'react';
 
+import Tooltip from '@/shared/components/common/tooltip/Tooltip';
 import useViewport from '@/shared/hooks/useViewport';
 import { cn } from '@/shared/lib/cn';
+import useModalStore from '@/shared/store/useModalStore';
+import { getStatusColor, getStatusLabel } from '@/shared/utils/application';
 
 import { ApplyStatus } from '../../types/apply';
+import ApplyStateModal from './ApplyStateModal';
 
 interface ApplyStateProps {
   status: ApplyStatus;
@@ -30,23 +35,14 @@ const ApplyState = ({
   // 지원일시 포맷팅
   const applicationDate = format(new Date(createdAt), 'yyyy.MM.dd HH:mm');
 
-  // 상태별 정보
-  const getStatusInfo = (status: ApplyStatus) => {
-    switch (status) {
-      case 'INTERVIEW_PENDING':
-        return { text: '면접 대기' };
-      case 'INTERVIEW_COMPLETED':
-        return { text: '면접 완료' };
-      case 'HIRED':
-        return { text: '채용 완료' };
-      case 'REJECTED':
-        return { text: '거절' };
-      default:
-        return { text: '알 수 없음' };
-    }
-  };
+  const statusInfo = getStatusLabel(status);
+  const statusColor = getStatusColor(status);
 
-  const statusInfo = getStatusInfo(status);
+  const { openModal } = useModalStore();
+
+  const handleApplyStateModal = () => {
+    openModal(<ApplyStateModal />);
+  };
 
   return (
     <div className="lg:rounded-lg lg:bg-gray-25 lg:p-24">
@@ -67,9 +63,31 @@ const ApplyState = ({
       </div>
 
       {/* 진행 상태 */}
-      <div className="flex items-center justify-between border-b border-gray-200 py-14 lg:border-b-0">
-        <span className="text-gray-400">진행 상태</span>
-        <span className={desktopStyle}>{statusInfo.text}</span>
+      <div className="flex w-full items-center justify-between border-b border-gray-200 py-14 lg:border-b-0">
+        <div className="flex items-center gap-2">
+          <span className="text-gray-400">진행 상태</span>
+          <Tooltip
+            content={() => (
+              <div className="flex items-center gap-2">
+                <div className="relative h-24 w-24 md:h-30 md:w-30">
+                  <Image fill alt="info" src="/icons/info.svg" />
+                </div>
+                <span className="text-xs md:text-md">
+                  알바폼 현재 진행상태를 변경할 수 있어요!
+                </span>
+              </div>
+            )}
+          >
+            <Image
+              alt="수정 아이콘"
+              height={24}
+              src="/icons/edit.svg"
+              width={24}
+              onClick={handleApplyStateModal}
+            />
+          </Tooltip>
+        </div>
+        <span className={cn(desktopStyle, statusColor)}>{statusInfo}</span>
       </div>
     </div>
   );

--- a/src/features/apply/components/apply-detail/ApplyState.tsx
+++ b/src/features/apply/components/apply-detail/ApplyState.tsx
@@ -3,7 +3,6 @@ import Image from 'next/image';
 import React from 'react';
 
 import Tooltip from '@/shared/components/common/tooltip/Tooltip';
-import useViewport from '@/shared/hooks/useViewport';
 import { cn } from '@/shared/lib/cn';
 import useModalStore from '@/shared/store/useModalStore';
 import { getStatusColor, getStatusLabel } from '@/shared/utils/application';
@@ -22,10 +21,6 @@ const ApplyState = ({
   createdAt,
   recruitmentEndDate,
 }: ApplyStateProps) => {
-  const { isDesktop } = useViewport();
-
-  const desktopStyle = isDesktop ? 'text-black' : '';
-
   // D-Day 계산
   const today = new Date();
   const recruitmentEnd = new Date(recruitmentEndDate);
@@ -59,7 +54,7 @@ const ApplyState = ({
             {dDayString}
           </span>
         </div>
-        <span className={desktopStyle}>{applicationDate}</span>
+        <span className="lg:text-black">{applicationDate}</span>
       </div>
 
       {/* 진행 상태 */}
@@ -87,7 +82,7 @@ const ApplyState = ({
             />
           </Tooltip>
         </div>
-        <span className={cn(desktopStyle, statusColor)}>{statusInfo}</span>
+        <span className={statusColor}>{statusInfo}</span>
       </div>
     </div>
   );

--- a/src/features/apply/components/apply-detail/ApplyState.tsx
+++ b/src/features/apply/components/apply-detail/ApplyState.tsx
@@ -70,13 +70,18 @@ const ApplyState = ({
               </div>
             }
           >
-            <Image
-              alt="수정 아이콘"
-              height={24}
-              src="/icons/edit.svg"
-              width={24}
+            <button
+              aria-label="진행 상태 수정"
+              type="button"
               onClick={handleApplyStateModal}
-            />
+            >
+              <Image
+                alt="수정 아이콘"
+                height={24}
+                src="/icons/edit.svg"
+                width={24}
+              />
+            </button>
           </Tooltip>
         </div>
         <span className={statusColor}>{statusInfo}</span>

--- a/src/features/apply/components/apply-detail/ApplyState.tsx
+++ b/src/features/apply/components/apply-detail/ApplyState.tsx
@@ -1,4 +1,3 @@
-import { differenceInCalendarDays, format } from 'date-fns';
 import Image from 'next/image';
 import React from 'react';
 
@@ -6,6 +5,7 @@ import Tooltip from '@/shared/components/common/tooltip/Tooltip';
 import { cn } from '@/shared/lib/cn';
 import useModalStore from '@/shared/store/useModalStore';
 import { getStatusColor, getStatusLabel } from '@/shared/utils/application';
+import { formatDateTime, getDDayString } from '@/shared/utils/format';
 
 import { ApplyStatus } from '../../types/apply';
 import ApplyStateModal from './ApplyStateModal';
@@ -22,13 +22,10 @@ const ApplyState = ({
   recruitmentEndDate,
 }: ApplyStateProps) => {
   // D-Day 계산
-  const today = new Date();
-  const recruitmentEnd = new Date(recruitmentEndDate);
-  const daysLeft = differenceInCalendarDays(recruitmentEnd, today);
-  const dDayString = daysLeft >= 0 ? `D-${daysLeft}` : '모집 마감';
+  const dDayString = getDDayString(recruitmentEndDate);
 
   // 지원일시 포맷팅
-  const applicationDate = format(new Date(createdAt), 'yyyy.MM.dd HH:mm');
+  const applicationDate = formatDateTime(createdAt);
 
   const statusInfo = getStatusLabel(status);
   const statusColor = getStatusColor(status);
@@ -62,7 +59,7 @@ const ApplyState = ({
         <div className="flex items-center gap-2">
           <span className="text-gray-400">진행 상태</span>
           <Tooltip
-            content={() => (
+            content={
               <div className="flex items-center gap-2">
                 <div className="relative h-24 w-24 md:h-30 md:w-30">
                   <Image fill alt="info" src="/icons/info.svg" />
@@ -71,7 +68,7 @@ const ApplyState = ({
                   알바폼 현재 진행상태를 변경할 수 있어요!
                 </span>
               </div>
-            )}
+            }
           >
             <Image
               alt="수정 아이콘"

--- a/src/features/apply/components/apply-detail/ApplyStateModal.tsx
+++ b/src/features/apply/components/apply-detail/ApplyStateModal.tsx
@@ -9,10 +9,14 @@ import RadioButton, {
 } from '@/shared/components/common/button/RadioButton';
 import useModalStore from '@/shared/store/useModalStore';
 
-const ApplyStateModal = () => {
+interface ApplyStateModalProps {
+  currentStatus: string;
+}
+
+const ApplyStateModal = ({ currentStatus }: ApplyStateModalProps) => {
   const { closeModal } = useModalStore();
 
-  const [selected, setSelected] = useState('INTERVIEW_PENDING');
+  const [selected, setSelected] = useState(currentStatus);
 
   const RADIO_OPTIONS: RadioOption[] = [
     { value: 'REJECTED', label: '거절' },

--- a/src/features/apply/components/apply-detail/ApplyStateModal.tsx
+++ b/src/features/apply/components/apply-detail/ApplyStateModal.tsx
@@ -21,6 +21,10 @@ const ApplyStateModal = () => {
     { value: 'HIRED', label: '채용 완료' },
   ];
 
+  const handleStateSubmit = () => {
+    console.log('선택된 상태:', selected);
+  };
+
   return (
     <div className="flex w-full flex-col gap-25 rounded-xl bg-gray-25 p-24 dark:bg-gray-900">
       <Modal.Header showCloseButton={false}>
@@ -55,6 +59,7 @@ const ApplyStateModal = () => {
           label="선택하기"
           type="button"
           variant="solid"
+          onClick={handleStatusSubmit}
         />
       </Modal.Footer>
     </div>

--- a/src/features/apply/components/apply-detail/ApplyStateModal.tsx
+++ b/src/features/apply/components/apply-detail/ApplyStateModal.tsx
@@ -22,6 +22,7 @@ const ApplyStateModal = () => {
   ];
 
   const handleStateSubmit = () => {
+    // TODO: API 호출로 실제 상태 업데이트
     console.log('선택된 상태:', selected);
   };
 
@@ -59,7 +60,7 @@ const ApplyStateModal = () => {
           label="선택하기"
           type="button"
           variant="solid"
-          onClick={handleStatusSubmit}
+          onClick={handleStateSubmit}
         />
       </Modal.Footer>
     </div>

--- a/src/features/apply/components/apply-detail/ApplyStateModal.tsx
+++ b/src/features/apply/components/apply-detail/ApplyStateModal.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import PrimaryButton from '@common/button/PrimaryButton';
+import Modal from '@common/modal/Modal';
+import { useState } from 'react';
+
+import RadioButton, {
+  RadioOption,
+} from '@/shared/components/common/button/RadioButton';
+import useModalStore from '@/shared/store/useModalStore';
+
+const ApplyStateModal = () => {
+  const { closeModal } = useModalStore();
+
+  const [selected, setSelected] = useState('INTERVIEW_PENDING');
+
+  const RADIO_OPTIONS: RadioOption[] = [
+    { value: 'REJECTED', label: '거절' },
+    { value: 'INTERVIEW_PENDING', label: '면접대기' },
+    { value: 'INTERVIEW_COMPLETED', label: '면접 완료' },
+    { value: 'HIRED', label: '채용 완료' },
+  ];
+
+  return (
+    <div className="flex w-full flex-col gap-25 rounded-xl bg-gray-25 p-24 dark:bg-gray-900">
+      <Modal.Header showCloseButton={false}>
+        <div className="flex flex-col gap-8 text-center lg:gap-16">
+          <h2 className="text-2lg lg:text-2xl dark:text-white">
+            진행상태 선택
+          </h2>
+          <p className="text-md text-gray-400 lg:text-xl">
+            현재 진행상태를 알려주세요.
+          </p>
+        </div>
+      </Modal.Header>
+      <Modal.Body>
+        <RadioButton
+          legend="현재 진행상태를 알려주세요."
+          name="applicationStatus"
+          options={RADIO_OPTIONS}
+          value={selected}
+          onChange={setSelected}
+        />
+      </Modal.Body>
+      <Modal.Footer className="mt-5">
+        <PrimaryButton
+          className="h-58 w-full py-20 text-lg lg:text-xl"
+          label="취소"
+          type="button"
+          variant="cancelOutline"
+          onClick={closeModal}
+        />
+        <PrimaryButton
+          className="h-58 w-full py-20 text-lg lg:text-xl"
+          label="선택하기"
+          type="button"
+          variant="solid"
+        />
+      </Modal.Footer>
+    </div>
+  );
+};
+
+export default ApplyStateModal;

--- a/src/features/apply/components/apply-detail/ApplyStateModal.tsx
+++ b/src/features/apply/components/apply-detail/ApplyStateModal.tsx
@@ -24,6 +24,7 @@ const ApplyStateModal = () => {
   const handleStateSubmit = () => {
     // TODO: API 호출로 실제 상태 업데이트
     console.log('선택된 상태:', selected);
+    closeModal();
   };
 
   return (

--- a/src/features/apply/components/apply-detail/index.tsx
+++ b/src/features/apply/components/apply-detail/index.tsx
@@ -23,9 +23,9 @@ const ApplyDetail = ({
   albaformData,
   applicationData,
   images = [
-    '/images/landing/albaform-clock.png',
-    '/images/landing/apply-girl.png',
-    '/images/landing/anywhere-application.png',
+    '/images/examples/store-example01.jpg',
+    '/images/examples/store-example02.jpg',
+    '/images/examples/store-example03.jpg',
   ],
 }: ApplyDetailProps) => {
   const sampleSlides: Slide[] = createSlidesFromUrls(images);

--- a/src/shared/components/common/button/RadioButton.tsx
+++ b/src/shared/components/common/button/RadioButton.tsx
@@ -2,6 +2,8 @@
 
 import { JSX } from 'react';
 
+import { cn } from '@/shared/lib/cn';
+
 export interface RadioOption {
   value: string;
   /** 화면에 표시될 라벨 */
@@ -82,9 +84,13 @@ const RadioButton = ({
           return (
             <label
               key={option.value}
-              className="flex w-327 cursor-pointer items-center justify-between rounded-lg border-2 border-line-100 bg-white p-14 font-medium transition-all duration-200 hover:border-mint-300 has-checked:border-mint-300 has-checked:bg-gray-50 has-disabled:cursor-not-allowed has-disabled:opacity-50 has-disabled:hover:border-line-100 lg:w-360 lg:px-24 lg:py-17"
+              className={cn(
+                `flex w-327 cursor-pointer items-center justify-between rounded-lg border-2 border-line-100 bg-white p-14 font-medium text-gray-600 transition-all duration-200`,
+                `hover:border-mint-300 has-checked:border-mint-300 has-checked:bg-mint-50 has-disabled:cursor-not-allowed has-disabled:opacity-50 has-disabled:hover:border-line-100 lg:w-360 lg:px-24 lg:py-17`,
+                `dark:bg-gray-800 dark:text-gray-400 dark:hover:border-mint-300 dark:has-checked:border-mint-300 dark:has-checked:bg-mint-50 dark:has-checked:text-black`
+              )}
             >
-              <span className="flex-1 text-sm text-gray-600 select-none lg:text-base">
+              <span className="flex-1 text-sm select-none lg:text-base">
                 {option.label}
               </span>
               <div className="relative inline-block">

--- a/src/shared/components/common/tooltip/Tooltip.tsx
+++ b/src/shared/components/common/tooltip/Tooltip.tsx
@@ -1,5 +1,7 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
+
+import { useClickOutside } from '@/shared/hooks/useClickOutside';
 
 import TooltipContentWrapper from './TooltipContentWrapper';
 
@@ -13,24 +15,21 @@ const Tooltip = ({ content, children }: ClickTooltipProps) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   // 바깥 클릭 시 닫힘
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (
-        wrapperRef.current &&
-        !wrapperRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  useClickOutside(wrapperRef, () => {
+    if (open) {
+      setOpen(false);
+    }
+  });
 
   const close = () => setOpen(false);
 
   return (
     <div ref={wrapperRef} className="relative inline-block">
-      <div className="cursor-pointer" onClick={() => setOpen(prev => !prev)}>
+      <div
+        className="cursor-pointer"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+      >
         {children}
       </div>
 

--- a/src/shared/components/common/tooltip/Tooltip.tsx
+++ b/src/shared/components/common/tooltip/Tooltip.tsx
@@ -1,30 +1,18 @@
 'use client';
-import { useRef, useState } from 'react';
-
-import { useClickOutside } from '@/shared/hooks/useClickOutside';
+import { useState } from 'react';
 
 import TooltipContentWrapper from './TooltipContentWrapper';
 
-interface ClickTooltipProps {
-  content: React.ReactNode | ((args: { close: () => void }) => React.ReactNode);
+interface TooltipProps {
+  content: React.ReactNode;
   children: React.ReactNode;
 }
 
-const Tooltip = ({ content, children }: ClickTooltipProps) => {
+const Tooltip = ({ content, children }: TooltipProps) => {
   const [open, setOpen] = useState(false);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  // 바깥 클릭 시 닫힘
-  useClickOutside(wrapperRef, () => {
-    if (open) {
-      setOpen(false);
-    }
-  });
-
-  const close = () => setOpen(false);
 
   return (
-    <div ref={wrapperRef} className="relative inline-block">
+    <div className="relative inline-block">
       <div
         className="cursor-pointer"
         onMouseEnter={() => setOpen(true)}
@@ -39,13 +27,9 @@ const Tooltip = ({ content, children }: ClickTooltipProps) => {
           <div className="absolute -top-4.5 left-1/4 z-0 h-12 w-12 -translate-x-1/2 rotate-45 bg-blue-300" />
 
           {/* 툴팁 본문 */}
-          {typeof content === 'function' ? (
-            <TooltipContentWrapper>{content({ close })}</TooltipContentWrapper>
-          ) : (
-            <TooltipContentWrapper>
-              <span>{content}</span>
-            </TooltipContentWrapper>
-          )}
+          <TooltipContentWrapper>
+            <span>{content}</span>
+          </TooltipContentWrapper>
         </div>
       )}
     </div>

--- a/src/shared/utils/format.ts
+++ b/src/shared/utils/format.ts
@@ -39,7 +39,11 @@ export const formatDateShort = (isoString: string): string => {
  * @returns 예: "2025.07.24 14:30"
  */
 export const formatDateTime = (isoString: string): string => {
-  return format(new Date(isoString), 'yyyy.MM.dd HH:mm');
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) {
+    return '-';
+  }
+  return format(date, 'yyyy.MM.dd HH:mm');
 };
 
 /**

--- a/src/shared/utils/format.ts
+++ b/src/shared/utils/format.ts
@@ -1,4 +1,4 @@
-import { differenceInCalendarDays } from 'date-fns';
+import { differenceInCalendarDays, format } from 'date-fns';
 
 /**
  * 마감일 기준 D-Day 텍스트 반환
@@ -31,6 +31,15 @@ export const formatDateLong = (isoString: string): string => {
 export const formatDateShort = (isoString: string): string => {
   const [year, month, day] = isoString.slice(0, 10).split('-');
   return `${year?.slice(2)}.${month}.${day}.`;
+};
+
+/**
+ * 날짜시간을 YYYY.MM.DD HH:mm 형식으로 포맷
+ * @param isoString ISO 형식의 날짜시간 문자열
+ * @returns 예: "2025.07.24 14:30"
+ */
+export const formatDateTime = (isoString: string): string => {
+  return format(new Date(isoString), 'yyyy.MM.dd HH:mm');
 };
 
 /**


### PR DESCRIPTION
## 📝 PR 내용 요약

- 툴팁 기존 클릭 이벤트에서 마우스 호버했을 때 노출되도록 변경
- 진행상태 선택을 할 수 있다는 안내 툴팁
- 진행상태 선택 모달창 구현

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #130

---

## 📸 스크린샷 (선택)

<img width="779" height="335" alt="image" src="https://github.com/user-attachments/assets/019e454f-4511-44dd-834b-b947ebf00b0d" />

<img width="1130" height="806" alt="image" src="https://github.com/user-attachments/assets/4d9321ac-f094-4136-bc2c-7933e4c0473c" />


---

## 💬 참고 사항

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지원 상태(진행 상태) 정보를 툴팁과 함께 시각적으로 개선하고, 상태 편집 아이콘 클릭 시 모달을 통해 상태를 변경할 수 있도록 기능 추가
  * 지원 상태 변경을 위한 모달 창(ApplyStateModal) 추가

* **버그 수정 및 개선**
  * 지원 상세 이미지의 기본값을 새로운 예시 이미지로 교체
  * 라디오 버튼 및 툴팁 컴포넌트의 스타일과 다크 모드 지원 개선
  * 툴팁이 마우스 오버/아웃으로 동작하도록 트리거 방식 변경 및 외부 클릭 감지 방식 개선
  * 날짜 및 상태 표시 형식 개선을 위한 유틸리티 함수 추가 및 적용
  * 지원자 프로필의 경력 및 전화번호 표시 형식 개선을 위한 유틸리티 함수 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->