### PR TITLE
[feat] 알바폼 이미지 업로드 구현

### DIFF
--- a/src/features/addform/api/index.ts
+++ b/src/features/addform/api/index.ts
@@ -22,5 +22,10 @@ export const useAddformApi = () => {
     ): Promise<AxiosResponse<CreateFormResponse>> => {
       return authAxios.patch('/forms', form);
     },
+    uploadImage: (file: File): Promise<AxiosResponse<{ url: string }>> => {
+      const formData = new FormData();
+      formData.append('image', file);
+      return authAxios.post('/images/upload', formData);
+    },
   };
 };

--- a/src/features/addform/components/AddformClient.tsx
+++ b/src/features/addform/components/AddformClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import Link from 'next/link';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
@@ -87,12 +88,14 @@ const AddformClient = ({ formId }: { formId?: string }) => {
             <h1 className="text-xl font-semibold lg:text-3xl">
               {formId ? '알바폼 수정하기' : '알바폼 만들기'}
             </h1>
-            <PrimaryButton
-              className="h-40 w-80 text-md text-gray-25 lg:h-56 lg:w-122 lg:text-xl"
-              label="작성 취소"
-              type="button"
-              variant="cancelSolid"
-            />
+            <Link href="/albalist">
+              <PrimaryButton
+                className="h-40 w-80 text-md text-gray-25 lg:h-56 lg:w-122 lg:text-xl"
+                label="작성 취소"
+                type="button"
+                variant="cancelSolid"
+              />
+            </Link>
           </header>
           {isDesktop || (
             <TabMenu

--- a/src/features/addform/components/RecruitContentForm.tsx
+++ b/src/features/addform/components/RecruitContentForm.tsx
@@ -12,7 +12,13 @@ import { cn } from '@/shared/lib/cn';
 
 import AddFormSection from './AddFormSection';
 
-const RecruitContentForm = ({ className }: { className?: string }) => {
+const RecruitContentForm = ({
+  className,
+  onImageChange,
+}: {
+  className?: string;
+  onImageChange: (files: File[]) => void;
+}) => {
   const {
     register,
     control,
@@ -82,7 +88,7 @@ const RecruitContentForm = ({ className }: { className?: string }) => {
       </AddFormSection>
       <AddFormSection>
         <Label htmlFor="uploadImage">이미지 첨부</Label>
-        <UploadMultipleImage id="uploadImage" onImageChange={() => {}} />
+        <UploadMultipleImage id="uploadImage" onImageChange={onImageChange} />
       </AddFormSection>
     </div>
   );

--- a/src/features/addform/queries/mutations.ts
+++ b/src/features/addform/queries/mutations.ts
@@ -30,3 +30,10 @@ export const useAddformMutation = () => {
     },
   });
 };
+
+export const useImageMutation = () => {
+  const { uploadImage } = useAddformApi();
+  return useMutation({
+    mutationFn: (file: File) => uploadImage(file),
+  });
+};

--- a/src/shared/components/common/uploadImage/UploadMultipleImage.tsx
+++ b/src/shared/components/common/uploadImage/UploadMultipleImage.tsx
@@ -40,25 +40,21 @@ const UploadMultipleImage = ({
     };
   }, []);
 
+  useEffect(() => {
+    onImageChange(currentFiles);
+  }, [currentFiles, onImageChange]);
+
   const handleImageChange = (files: File[]) => {
     if (!files[0]) return;
     const urls = files.map(file => URL.createObjectURL(file));
     setPreviewImages(prev => [...prev, ...urls]);
-    setCurrentFiles(prev => {
-      const newFiles = [...prev, ...files];
-      onImageChange(newFiles);
-      return newFiles;
-    });
+    setCurrentFiles(prev => [...prev, ...files]);
   };
 
   const removeImage = (idx: number) => {
     if (previewImages[idx]) URL.revokeObjectURL(previewImages[idx]);
     setPreviewImages(prev => prev.filter((_, index) => index !== idx));
-    setCurrentFiles(prev => {
-      const newFiles = prev.filter((_, index) => index !== idx);
-      onImageChange(newFiles);
-      return newFiles;
-    });
+    setCurrentFiles(prev => prev.filter((_, index) => index !== idx));
   };
 
   return (


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 알바폼 제출하기에 이미지 업로드를 구현했습니다

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #148

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---

## 💬 참고 사항
남은 작업: 메뉴에 작성중 상태 표시, 수정하기, 임시 저장


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이미지 파일을 업로드하여 폼 제출 시 이미지 URL을 함께 전송할 수 있도록 기능이 추가되었습니다.
  * 이미지 업로드를 위한 별도의 커스텀 훅이 추가되었습니다.
  * 이미지 업로드 콜백을 부모 컴포넌트에서 처리할 수 있도록 폼 컴포넌트의 props가 확장되었습니다.

* **버그 수정**
  * 이미지 파일 변경 시 이미지 변경 콜백이 상태 변경 이후에 일관되게 호출되도록 개선되었습니다.

* **기타**
  * 이미지 업로드와 폼 제출의 진행 상태가 명확하게 표시되도록 로딩 상태 관리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->