### PR TITLE
[feat] 알바토크 상세 페이지 댓글 CRUD

### DIFF
--- a/src/features/albatalk/api/albatalkApi.ts
+++ b/src/features/albatalk/api/albatalkApi.ts
@@ -7,8 +7,13 @@ import {
   AlbatalkDetailResponseSchema,
   type AlbatalksResponse,
   AlbatalksResponseSchema,
+  CommentResponse,
+  CommentResponseSchema,
+  CommentsResponse,
+  CommentsResponseSchema,
   type GetAlbatalksParams,
   GetAlbatalksParamsSchema,
+  GetCommentsParams,
 } from '../schemas/albatalk.schema';
 
 /**
@@ -65,4 +70,67 @@ export const removeAlbatalkLike = async (
   authAxios: AxiosInstance
 ): Promise<void> => {
   await authAxios.delete(`/posts/${postId}/like`);
+};
+
+/**
+ * 댓글 목록 조회
+ * GET /{teamId}/posts/{postId}/comments
+ */
+export const fetchComments = async (
+  postId: number,
+  authAxios: AxiosInstance,
+  params?: GetCommentsParams
+): Promise<CommentsResponse> => {
+  const queryParams = new URLSearchParams();
+
+  if (params?.page) queryParams.append('page', params.page.toString());
+  if (params?.pageSize)
+    queryParams.append('pageSize', params.pageSize.toString());
+
+  const queryString = queryParams.toString();
+  const url = `/posts/${postId}/comments${queryString ? `?${queryString}` : ''}`;
+
+  const response = await authAxios.get(url);
+  return CommentsResponseSchema.parse(response.data);
+};
+
+/**
+ * 댓글 작성
+ * POST /posts/{postId}/comments
+ */
+export const createComment = async (
+  postId: number,
+  content: string,
+  authAxios: AxiosInstance
+): Promise<CommentResponse> => {
+  const response = await authAxios.post(`/posts/${postId}/comments`, {
+    content,
+  });
+  return CommentResponseSchema.parse(response.data);
+};
+
+/**
+ * 댓글 수정
+ * PATCH /comments/{commentId}
+ */
+export const updateComment = async (
+  commentId: number,
+  content: string,
+  authAxios: AxiosInstance
+): Promise<CommentResponse> => {
+  const response = await authAxios.patch(`/comments/${commentId}`, {
+    content,
+  });
+  return CommentResponseSchema.parse(response.data);
+};
+
+/**
+ * 댓글 삭제
+ * DELETE /comments/{commentId}
+ */
+export const deleteComment = async (
+  commentId: number,
+  authAxios: AxiosInstance
+): Promise<void> => {
+  await authAxios.delete(`/comments/${commentId}`);
 };

--- a/src/features/albatalk/api/albatalkApi.ts
+++ b/src/features/albatalk/api/albatalkApi.ts
@@ -74,7 +74,6 @@ export const removeAlbatalkLike = async (
 
 /**
  * 댓글 목록 조회
- * GET /{teamId}/posts/{postId}/comments
  */
 export const fetchComments = async (
   postId: number,

--- a/src/features/albatalk/components/albatalk-detail/CommentContent.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentContent.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+
+interface CommentContentProps {
+  content: string;
+  className?: string;
+}
+
+const CommentContent = ({ content, className = '' }: CommentContentProps) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const isLongComment = content.length > 100 || content.split('\n').length > 3;
+
+  return (
+    <div className={className}>
+      <p
+        className={`break-words whitespace-pre-wrap ${
+          expanded ? '' : 'line-clamp-3'
+        }`}
+      >
+        {content}
+      </p>
+
+      {isLongComment && (
+        <button
+          className="mt-8 text-mint-400 hover:underline"
+          type="button"
+          onClick={() => setExpanded(prev => !prev)}
+        >
+          {expanded ? '접기' : '더보기'}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default CommentContent;

--- a/src/features/albatalk/components/albatalk-detail/CommentForm.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentForm.tsx
@@ -26,9 +26,6 @@ const CommentForm = ({ albatalkId, onSubmit }: CommentFormProps) => {
       {
         onSuccess: () => {
           setContent('');
-          if (textareaRef.current) {
-            textareaRef.current.value = '';
-          }
           onSubmit?.(trimmedContent);
         },
         onError: error => {

--- a/src/features/albatalk/components/albatalk-detail/CommentItem.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentItem.tsx
@@ -96,7 +96,7 @@ const CommentItem = ({ comment, onEdit, onDelete }: CommentItemProps) => {
         </div>
       ) : (
         // 일반 보기 모드일 때 (댓글 내용을 보여줌)
-        <p className="pl-4 text-sm leading-relaxed md:text-base lg:text-xl">
+        <p className="pl-4 text-sm leading-relaxed break-words whitespace-pre-wrap md:text-base lg:text-xl">
           {comment.content}
         </p>
       )}

--- a/src/features/albatalk/components/albatalk-detail/CommentItem.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentItem.tsx
@@ -8,6 +8,7 @@ import KebabMenuDropdown from '@/shared/components/common/kebabMenuDropdown';
 
 import { Comment } from '../../schemas/albatalk.schema';
 import AlbatalkMetaInfoUser from '../albatalk-item/AlbatalkMetaInfoUser';
+import CommentContent from './CommentContent';
 
 interface CommentItemProps {
   comment: Comment;
@@ -96,9 +97,10 @@ const CommentItem = ({ comment, onEdit, onDelete }: CommentItemProps) => {
         </div>
       ) : (
         // 일반 보기 모드일 때 (댓글 내용을 보여줌)
-        <p className="pl-4 text-sm leading-relaxed break-words whitespace-pre-wrap md:text-base lg:text-xl">
-          {comment.content}
-        </p>
+        <CommentContent
+          className="pl-4 text-sm leading-relaxed md:text-base lg:text-xl"
+          content={comment.content}
+        />
       )}
     </div>
   );

--- a/src/features/albatalk/components/albatalk-detail/CommentList.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentList.tsx
@@ -1,60 +1,44 @@
 'use client';
 
-import Image from 'next/image';
-import { useState } from 'react';
+import EmptyCard from '@/shared/components/common/EmptyCard';
 
+import {
+  useDeleteAlbatalkComment,
+  useUpdateAlbatalkComment,
+} from '../../hooks/useAlbatalk';
 import { Comment } from '../../schemas/albatalk.schema';
 import CommentItem from './CommentItem';
 
 interface CommentListProps {
-  initialComments: Comment[];
+  comments: Comment[];
+  albatalkId: number;
 }
 
-const CommentList = ({ initialComments }: CommentListProps) => {
-  const [comments, setComments] = useState(initialComments || []);
-
-  console.log(comments);
+const CommentList = ({ comments, albatalkId }: CommentListProps) => {
+  const updateCommentMutation = useUpdateAlbatalkComment();
+  const deleteCommentMutation = useDeleteAlbatalkComment();
 
   // 댓글 수정 로직을 처리하는 함수
   const handleEditComment = (commentId: number, newContent: string) => {
-    // TODO: 여기에 실제 API 호출 로직 (서버에 댓글 수정 요청)
-    console.log(
-      `[CommentList] 댓글 ID: ${commentId}, 새로운 내용: "${newContent}" 수정 요청`
-    );
-
-    // API 호출 성공 시, 상태 업데이트
-    setComments(prevComments =>
-      prevComments.map(comment =>
-        comment.id === commentId ? { ...comment, content: newContent } : comment
-      )
-    );
+    updateCommentMutation.mutate({
+      commentId,
+      content: newContent,
+      postId: albatalkId,
+    });
   };
 
   // 댓글 삭제 로직을 처리하는 함수
   const handleDeleteComment = (commentId: number) => {
-    // TODO: 여기에 실제 API 호출 로직 (서버에 댓글 삭제 요청)
-    console.log(`[CommentList] 댓글 ID: ${commentId} 삭제 요청`);
-
-    // API 호출 성공 시, 상태 업데이트
-    setComments(prevComments =>
-      prevComments.filter(comment => comment.id !== commentId)
-    );
+    deleteCommentMutation.mutate({
+      commentId,
+      postId: albatalkId,
+    });
   };
 
   if (comments.length === 0) {
     return (
       <div className="my-100 flex flex-col gap-32 self-center text-center">
-        <Image
-          alt="empty-list"
-          className="self-center"
-          height={120}
-          src="/icons/empty-list.svg"
-          width={120}
-        />
-        <div>
-          <p className="mb-1 text-gray-500">등록된 댓글이 없어요</p>
-          <p className="text-sm text-gray-400">댓글을 등록해서 소통해주세요</p>
-        </div>
+        <EmptyCard type="albaTalkComment" />
       </div>
     );
   }

--- a/src/features/albatalk/components/albatalk-detail/CommentSection.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentSection.tsx
@@ -1,23 +1,48 @@
 'use client';
-import { useState } from 'react';
+import LoadingSpinner from '@/shared/components/ui/LoadingSpinner';
 
+import { useAlbatalkComments } from '../../hooks/useAlbatalk';
 import { CommentsResponse } from '../../schemas/albatalk.schema';
 import CommentForm from './CommentForm';
 import CommentList from './CommentList';
 import CommentStatus from './CommentStatus';
 
 interface CommentSectionProps {
-  postId: number;
-  initialComments: CommentsResponse;
+  albatalkId: number;
+  initialComments?: CommentsResponse;
 }
 
-const CommentSection = ({ postId, initialComments }: CommentSectionProps) => {
-  const [comments, setComments] = useState(initialComments);
+const CommentSection = ({
+  albatalkId,
+  initialComments,
+}: CommentSectionProps) => {
+  const {
+    data: commentsResponse,
+    isPending,
+    isError,
+    error,
+  } = useAlbatalkComments(albatalkId, { page: 1, pageSize: 10 });
+
+  const currentComments = commentsResponse || initialComments;
+
+  if (isPending && !initialComments) {
+    return <LoadingSpinner size="lg" />;
+  }
+
+  if (isError) {
+    console.error('댓글 조회 에러:', error);
+    return <div className="text-red-500">댓글을 불러오는데 실패했습니다.</div>;
+  }
+
+  if (!currentComments) {
+    return <div>댓글 데이터를 불러올 수 없습니다.</div>;
+  }
+
   return (
     <div className="flex flex-col gap-24 lg:gap-40">
-      <CommentStatus count={initialComments.totalItemCount} />
-      <CommentForm postId={postId} />
-      <CommentList initialComments={comments.data} />
+      <CommentStatus count={currentComments.totalItemCount} />
+      <CommentForm albatalkId={albatalkId} />
+      <CommentList albatalkId={albatalkId} comments={currentComments.data} />
     </div>
   );
 };

--- a/src/features/albatalk/components/albatalk-detail/index.tsx
+++ b/src/features/albatalk/components/albatalk-detail/index.tsx
@@ -10,6 +10,7 @@ import LoadingSpinner from '@/shared/components/ui/LoadingSpinner';
 import { useAlbatalkDetail } from '../../hooks/useAlbatalk';
 import AlbatalkDetailContent from './AlbatalkDetailContent';
 import AlbatalkDetailHeader from './AlbatalkDetailHeader';
+import CommentSection from './CommentSection';
 
 interface AlbatalkDetailProps {
   albatalkId: number;
@@ -54,13 +55,13 @@ const AlbatalkDetail = ({ albatalkId }: AlbatalkDetailProps) => {
   }
 
   return (
-    <div className="flex flex-col gap-40 pt-44">
+    <div className="mb-100 flex flex-col gap-40 pt-44">
       <AlbatalkDetailHeader data={albatalk} />
       <AlbatalkDetailContent
         content={albatalk.content}
         imageUrl={albatalk.imageUrl}
       />
-      {/* <CommentSection initialComments={comments} postId={data.id} /> */}
+      <CommentSection albatalkId={albatalk.id} />
     </div>
   );
 };

--- a/src/features/albatalk/hooks/useAlbatalk.ts
+++ b/src/features/albatalk/hooks/useAlbatalk.ts
@@ -5,11 +5,19 @@ import { useAxiosWithAuth } from '@/shared/lib/axios';
 
 import {
   addAlbatalkLike,
+  createComment,
+  deleteComment,
   fetchAlbatalkDetail,
   fetchAlbatalks,
+  // 댓글 관련 API 함수들
+  fetchComments,
   removeAlbatalkLike,
+  updateComment,
 } from '../api/albatalkApi';
-import type { GetAlbatalksParams } from '../schemas/albatalk.schema';
+import type {
+  GetAlbatalksParams,
+  GetCommentsParams,
+} from '../schemas/albatalk.schema';
 
 // 쿼리 키 팩토리
 export const albatalkKeys = {
@@ -21,6 +29,8 @@ export const albatalkKeys = {
   detail: (id: number) => [...albatalkKeys.details(), id] as const,
   comments: (postId: number) =>
     [...albatalkKeys.all, 'comments', postId] as const,
+  commentsList: (postId: number, params?: GetCommentsParams) =>
+    [...albatalkKeys.comments(postId), 'list', params] as const,
 };
 
 /**
@@ -99,6 +109,118 @@ export const useRemoveAlbatalkLike = () => {
     },
     onError: error => {
       console.error('좋아요 취소 실패:', error);
+    },
+  });
+};
+
+// ========== 댓글 관련 훅들 ==========
+
+/**
+ * 댓글 목록 조회 훅
+ */
+export const useAlbatalkComments = (
+  postId: number,
+  params?: GetCommentsParams
+) => {
+  const authAxios = useAxiosWithAuth();
+  const { data: session, status } = useSession();
+
+  const isSessionLoading = status === 'loading';
+  const hasAccessToken = !!session?.accessToken;
+
+  return useQuery({
+    queryKey: albatalkKeys.commentsList(postId, params),
+    queryFn: () => fetchComments(postId, authAxios, params),
+    enabled: !isSessionLoading && hasAccessToken,
+    staleTime: 1000 * 60 * 5, // 5분
+    gcTime: 1000 * 60 * 10, // 10분
+  });
+};
+
+/**
+ * 댓글 작성 훅
+ */
+export const useCreateAlbatalkComment = () => {
+  const queryClient = useQueryClient();
+  const authAxios = useAxiosWithAuth();
+
+  return useMutation({
+    mutationFn: ({ postId, content }: { postId: number; content: string }) =>
+      createComment(postId, content, authAxios),
+    onSuccess: (_, { postId }) => {
+      // 해당 게시글의 댓글 목록 무효화
+      queryClient.invalidateQueries({
+        queryKey: albatalkKeys.comments(postId),
+      });
+
+      // 게시글 상세 정보도 무효화 (댓글 수 업데이트를 위해)
+      queryClient.invalidateQueries({
+        queryKey: albatalkKeys.detail(postId),
+      });
+    },
+    onError: error => {
+      console.error('댓글 작성 실패:', error);
+    },
+  });
+};
+
+/**
+ * 댓글 수정 훅
+ */
+export const useUpdateAlbatalkComment = () => {
+  const queryClient = useQueryClient();
+  const authAxios = useAxiosWithAuth();
+
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      content,
+      postId,
+    }: {
+      commentId: number;
+      content: string;
+      postId: number;
+    }) => updateComment(commentId, content, authAxios),
+    onSuccess: (_, { postId }) => {
+      // 해당 게시글의 댓글 목록 무효화
+      queryClient.invalidateQueries({
+        queryKey: albatalkKeys.comments(postId),
+      });
+    },
+    onError: error => {
+      console.error('댓글 수정 실패', error);
+    },
+  });
+};
+
+/**
+ * 댓글 삭제 훅
+ */
+export const useDeleteAlbatalkComment = () => {
+  const queryClient = useQueryClient();
+  const authAxios = useAxiosWithAuth();
+
+  return useMutation({
+    mutationFn: ({
+      commentId,
+      postId,
+    }: {
+      commentId: number;
+      postId: number;
+    }) => deleteComment(commentId, authAxios),
+    onSuccess: (_, { postId }) => {
+      // 해당 게시글의 댓글 목록 무효화
+      queryClient.invalidateQueries({
+        queryKey: albatalkKeys.comments(postId),
+      });
+
+      // 게시글 상세 정보도 무효화 (댓글 수 업데이트를 위해)
+      queryClient.invalidateQueries({
+        queryKey: albatalkKeys.detail(postId),
+      });
+    },
+    onError: error => {
+      console.error('댓글 삭제 실패:', error);
     },
   });
 };

--- a/src/features/albatalk/schemas/albatalk.schema.ts
+++ b/src/features/albatalk/schemas/albatalk.schema.ts
@@ -70,6 +70,36 @@ export const CommentsResponseSchema = z.object({
   totalPages: z.number(),
 });
 
+// 댓글 조회 파라미터
+export const GetCommentsParamsSchema = z.object({
+  page: z.number().optional().default(1),
+  pageSize: z.number().optional().default(10),
+});
+
+// 댓글 작성 파라미터
+export const CreateCommentParamsSchema = z.object({
+  teamId: z.string(),
+  postId: z.number(),
+  content: z.string().min(1, '댓글 내용을 입력해주세요'),
+});
+
+// 댓글 수정 파라미터
+export const UpdateCommentParamsSchema = z.object({
+  teamId: z.string(),
+  commentId: z.number(),
+  postId: z.number(),
+  content: z.string().min(1, '댓글 내용을 입력해주세요'),
+});
+
+// 댓글 작성/수정 응답 스키마
+export const CommentResponseSchema = z.object({
+  id: z.number(),
+  writer: WriterSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  content: z.string(),
+});
+
 // 스키마로부터 타입을 추론
 export type Writer = z.infer<typeof WriterSchema>;
 export type Albatalk = z.infer<typeof AlbatalkSchema>;
@@ -78,6 +108,11 @@ export type AlbatalkDetailResponse = z.infer<
   typeof AlbatalkDetailResponseSchema
 >;
 export type GetAlbatalksParams = z.infer<typeof GetAlbatalksParamsSchema>;
+export type SearchParams = z.infer<typeof SearchParamsSchema>;
+
 export type Comment = z.infer<typeof CommentSchema>;
 export type CommentsResponse = z.infer<typeof CommentsResponseSchema>;
-export type SearchParams = z.infer<typeof SearchParamsSchema>;
+export type GetCommentsParams = z.infer<typeof GetCommentsParamsSchema>;
+export type CreateCommentParams = z.infer<typeof CreateCommentParamsSchema>;
+export type UpdateCommentParams = z.infer<typeof UpdateCommentParamsSchema>;
+export type CommentResponse = z.infer<typeof CommentResponseSchema>;

--- a/src/features/albatalk/schemas/albatalk.schema.ts
+++ b/src/features/albatalk/schemas/albatalk.schema.ts
@@ -78,14 +78,12 @@ export const GetCommentsParamsSchema = z.object({
 
 // 댓글 작성 파라미터
 export const CreateCommentParamsSchema = z.object({
-  teamId: z.string(),
   postId: z.number(),
   content: z.string().min(1, '댓글 내용을 입력해주세요'),
 });
 
 // 댓글 수정 파라미터
 export const UpdateCommentParamsSchema = z.object({
-  teamId: z.string(),
   commentId: z.number(),
   postId: z.number(),
   content: z.string().min(1, '댓글 내용을 입력해주세요'),


### PR DESCRIPTION
## 📝 PR 내용 요약

- 댓글 CRUD 기능 구현 (작성, 조회, 수정, 삭제)
- React Query를 활용한 실시간 댓글 상태 관리
- 댓글 줄바꿈 처리 기능 추가
- 댓글 내용이 길 때 더보기 버튼 추가
- Zod 스키마를 통한 댓글 데이터 유효성 검증 강화

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #153 

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---

## 💬 참고 사항

- 무한 스크롤 추후 적용

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 게시글에 대한 댓글 조회, 작성, 수정, 삭제 기능이 추가되었습니다.
  * 댓글 목록을 불러오고, 새 댓글을 작성하거나 기존 댓글을 수정 및 삭제할 수 있습니다.
  * 댓글 내용이 길 경우, 더보기/접기 버튼으로 확장 및 축소가 가능합니다.

* **리팩터**
  * 댓글 관련 컴포넌트들이 내부 상태 대신 외부 데이터 및 API 연동 방식으로 개선되었습니다.
  * 일부 prop 이름이 명확하게 변경되었습니다. (예: postId → albatalkId)
  * 댓글 입력 및 목록 UI가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->