### PR TITLE
[feat] 지원내역 상태 수정 및 지원서(이력서) 다운로드

### DIFF
--- a/src/features/albatalk/components/albatalk-detail/CommentForm.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentForm.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from 'react';
 
 import PrimaryButton from '@/shared/components/common/button/PrimaryButton';
 import Textarea from '@/shared/components/common/input/Textarea';
+import { usePopupStore } from '@/shared/store/popupStore';
 
 import { useCreateAlbatalkComment } from '../../hooks/useAlbatalk';
 
@@ -16,6 +17,7 @@ const CommentForm = ({ albatalkId, onSubmit }: CommentFormProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [content, setContent] = useState('');
   const createCommentMutation = useCreateAlbatalkComment();
+  const { showPopup } = usePopupStore();
 
   const handleSubmit = () => {
     const trimmedContent = content.trim();
@@ -27,9 +29,11 @@ const CommentForm = ({ albatalkId, onSubmit }: CommentFormProps) => {
         onSuccess: () => {
           setContent('');
           onSubmit?.(trimmedContent);
+          showPopup('댓글이 등록되었습니다.', 'success');
         },
         onError: error => {
           console.error('댓글 작성 실패: ', error);
+          showPopup('댓글 등록 중 오류가 발생했습니다.', 'error');
         },
       }
     );

--- a/src/features/albatalk/components/albatalk-form/AddtalkClient.tsx
+++ b/src/features/albatalk/components/albatalk-form/AddtalkClient.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 
 import { useImageMutation } from '@/features/addform/queries/mutations';
 import LoadingSpinner from '@/shared/components/ui/LoadingSpinner';
+import { usePopupStore } from '@/shared/store/popupStore';
 
 import {
   useAlbatalkDetail,
@@ -27,6 +28,7 @@ interface AddtalkClientProps {
 const AddtalkClient = ({ albatalkId }: AddtalkClientProps) => {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement>(null);
+  const { showPopup } = usePopupStore();
 
   const isEditMode = !!albatalkId;
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
@@ -97,10 +99,10 @@ const AddtalkClient = ({ albatalkId }: AddtalkClientProps) => {
           postId: numericAlbatalkId,
           ...finalData, // 최종 데이터 사용
         });
-        alert('알바토크가 성공적으로 수정되었습니다!');
+        showPopup('알바토크가 성공적으로 수정되었습니다!', 'success');
       } else {
         await createMutation.mutateAsync(finalData); // 최종 데이터 사용
-        alert('알바토크가 성공적으로 등록되었습니다!');
+        showPopup('알바토크가 성공적으로 등록되었습니다!', 'success');
       }
 
       router.push('/albatalk');

--- a/src/features/albatalk/components/albatalk-item/index.tsx
+++ b/src/features/albatalk/components/albatalk-item/index.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { useAuthSession } from '@/features/auth';
+import { usePopupStore } from '@/shared/store/popupStore';
 
 import { Albatalk } from '../../schemas/albatalk.schema';
 import AlbatalkCardHeader from './AlbatalkCardHeader';
@@ -14,12 +15,13 @@ interface AlbatalkItemProps {
 const AlbatalkItem = ({ albatalk }: AlbatalkItemProps) => {
   const router = useRouter();
   const { isAuthenticated } = useAuthSession();
+  const { showPopup } = usePopupStore();
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
 
     if (!isAuthenticated) {
-      alert('로그인이 필요한 페이지입니다.');
+      showPopup('로그인이 필요한 페이지입니다.', 'error');
       router.push('/signin');
       return;
     }

--- a/src/features/application/api/applicationDetail.ts
+++ b/src/features/application/api/applicationDetail.ts
@@ -31,7 +31,7 @@ export const useApplicationDetailApi = () => {
       applicationId: string,
       data: { status: string }
     ) => {
-      return authAxios.patch(`/applications/${applicationId}`, data);
+      return authAxios.patch(`applications/${applicationId}`, data);
     },
   };
 };

--- a/src/features/application/api/applicationDetail.ts
+++ b/src/features/application/api/applicationDetail.ts
@@ -18,5 +18,20 @@ export const useApplicationDetailApi = () => {
     getApplicationById: (applicationId: string) => {
       return authAxios.get(`applications/${applicationId}`);
     },
+
+    // 이력서 다운로드
+    downloadResume: (resumeId: string) => {
+      return authAxios.get(`${resumeId}/download`, {
+        responseType: 'blob',
+      });
+    },
+
+    // 지원 상태 수정 (사장님용)
+    updateApplicationStatus: (
+      applicationId: string,
+      data: { status: string }
+    ) => {
+      return authAxios.patch(`/applications/${applicationId}`, data);
+    },
   };
 };

--- a/src/features/application/components/application-detail/ApplicationProfile.tsx
+++ b/src/features/application/components/application-detail/ApplicationProfile.tsx
@@ -69,11 +69,13 @@ const ApplicationProfile = ({ data }: ApplicationProfileProps) => {
               <button
                 aria-label="이력서 다운로드"
                 className="flex"
+                disabled={downloadMutation.isPending}
                 type="button"
                 onClick={handleDownloadResume}
               >
                 <Image
                   alt="다운로드 아이콘"
+                  className={downloadMutation.isPending ? 'opacity-50' : ''}
                   height={24}
                   src="/icons/download.svg"
                   width={24}

--- a/src/features/application/components/application-detail/ApplicationProfile.tsx
+++ b/src/features/application/components/application-detail/ApplicationProfile.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image';
 import React from 'react';
 
-import { useSessionUtils } from '@/shared/lib/auth/use-session-utils';
 import { usePopupStore } from '@/shared/store/popupStore';
 import { getExperienceLabel } from '@/shared/utils/application';
 import { formatPhoneNumber } from '@/shared/utils/format';
 
+import { useResumeDownloadMutation } from '../../queries/queries';
 import { ApplicationResponse } from '../../types/application';
 
 interface ApplicationProfileProps {
@@ -13,16 +13,25 @@ interface ApplicationProfileProps {
 }
 
 const ApplicationProfile = ({ data }: ApplicationProfileProps) => {
-  const { isOwner } = useSessionUtils();
-  const { name, phoneNumber, experienceMonths, resumeName, introduction } =
-    data;
+  const { name, phoneNumber, experienceMonths, introduction } = data;
   const { showPopup } = usePopupStore();
 
-  const handleDownloadResume = () => {
+  const downloadMutation = useResumeDownloadMutation({
+    onSuccess: () => {
+      showPopup('이력서 다운로드가 완료되었습니다.', 'success');
+    },
+    onError: () => {
+      showPopup('이력서 다운로드에 실패했습니다.', 'error');
+    },
+  });
+
+  const handleDownloadResume = async () => {
     if (!data.resumeId) {
       showPopup('다운로드에 필요한 정보가 부족합니다.', 'info');
       return;
     }
+
+    downloadMutation.mutate(data.resumeId);
   };
 
   return (
@@ -56,24 +65,20 @@ const ApplicationProfile = ({ data }: ApplicationProfileProps) => {
           <div className="py-4">
             <div className="mb-4 py-14 text-gray-400">이력서</div>
             <div className="flex items-center justify-between rounded-lg bg-gray-50 p-14">
-              <span className="text-gray-700">
-                {resumeName || '이력서 없음'}
-              </span>
-              {isOwner && (
-                <button
-                  aria-label="이력서 다운로드"
-                  className="flex"
-                  type="button"
-                  onClick={handleDownloadResume}
-                >
-                  <Image
-                    alt="다운로드 아이콘"
-                    height={24}
-                    src="/icons/download.svg"
-                    width={24}
-                  />
-                </button>
-              )}
+              <span className="text-gray-700">{name}_이력서</span>
+              <button
+                aria-label="이력서 다운로드"
+                className="flex"
+                type="button"
+                onClick={handleDownloadResume}
+              >
+                <Image
+                  alt="다운로드 아이콘"
+                  height={24}
+                  src="/icons/download.svg"
+                  width={24}
+                />
+              </button>
             </div>
           </div>
 

--- a/src/features/application/components/application-detail/ApplicationState.tsx
+++ b/src/features/application/components/application-detail/ApplicationState.tsx
@@ -15,12 +15,14 @@ interface ApplicationStateProps {
   status: ApplicationStatus;
   createdAt: string;
   recruitmentEndDate: string;
+  applicationId: string;
 }
 
 const ApplicationState = ({
   status,
   createdAt,
   recruitmentEndDate,
+  applicationId,
 }: ApplicationStateProps) => {
   const { isOwner } = useSessionUtils();
   // D-Day 계산
@@ -35,7 +37,12 @@ const ApplicationState = ({
   const { openModal } = useModalStore();
 
   const handleApplyStateModal = () => {
-    openModal(<ApplicationStateModal currentStatus={status} />);
+    openModal(
+      <ApplicationStateModal
+        applicationId={applicationId}
+        currentStatus={status}
+      />
+    );
   };
 
   return (

--- a/src/features/application/components/application-detail/ApplicationStateModal.tsx
+++ b/src/features/application/components/application-detail/ApplicationStateModal.tsx
@@ -45,12 +45,17 @@ const ApplicationStateModal = ({
   });
 
   const handleStateSubmit = () => {
-    closeModal();
-
-    updateStatusMutation.mutate({
-      applicationId,
-      status: selected as ApplicationStatus,
-    });
+    updateStatusMutation.mutate(
+      {
+        applicationId,
+        status: selected as ApplicationStatus,
+      },
+      {
+        onSuccess: () => {
+          closeModal();
+        },
+      }
+    );
   };
 
   return (

--- a/src/features/application/components/application-detail/index.tsx
+++ b/src/features/application/components/application-detail/index.tsx
@@ -242,6 +242,7 @@ const ApplicationDetail = ({
         </div>
         <div>
           <ApplicationState
+            applicationId={ applicationData.id}
             createdAt={applicationData.createdAt}
             recruitmentEndDate={albaformData.recruitmentEndDate}
             status={applicationData.status}

--- a/src/features/application/queries/queries.ts
+++ b/src/features/application/queries/queries.ts
@@ -1,4 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationOptions,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { AxiosResponse } from 'axios';
 import { useSession } from 'next-auth/react';
 
 import { MockAlbaItem } from '@/features/alba/types/MockAlbaItem';
@@ -48,7 +54,7 @@ export const useMyApplicationQuery = (formId: string, options = {}) => {
     },
     enabled: status === 'authenticated' && !!session?.accessToken && !!formId,
     ...DEFAULT_QUERY_OPTIONS,
-    ...options, // 외부 옵션 적용
+    ...options,
   });
 };
 
@@ -71,6 +77,142 @@ export const useApplicationByIdQuery = (
     enabled:
       status === 'authenticated' && !!session?.accessToken && !!applicationId,
     ...DEFAULT_QUERY_OPTIONS,
-    ...options, // 외부 옵션 적용
+    ...options,
+  });
+};
+
+// 이력서 다운로드
+type DownloadOptions = UseMutationOptions<AxiosResponse<Blob>, unknown, number>;
+export const useResumeDownloadMutation = (options: DownloadOptions = {}) => {
+  const api = useApplicationDetailApi();
+
+  return useMutation({
+    mutationFn: async (resumeId: number) => {
+      const response = await api.downloadResume(String(resumeId));
+      return response;
+    },
+    onSuccess: response => {
+      // 파일 다운로드 처리
+      const blob = new Blob([response.data]);
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+
+      // 파일명 설정 (response header에서 가져오거나 기본값 사용)
+      const contentDisposition = response.headers['content-disposition'];
+      let filename = 'resume.pdf'; // 기본 파일명
+
+      if (contentDisposition) {
+        // "attachment; filename="1754115498904_qzqyktg178.pdf"" 형태에서 파일명 추출
+        const filenameMatch = contentDisposition.match(/filename="([^"]+)"/);
+        if (filenameMatch) {
+          filename = filenameMatch[1];
+        }
+      }
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+
+      // 메모리 정리
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+
+      options.onSuccess?.(response, response.config.data, undefined);
+    },
+    onError: error => {
+      console.error('Resume download failed:', error);
+    },
+  });
+};
+
+// 지원 상태 수정 - 단순하고 확실한 낙관적 업데이트
+type UpdateStatusVariables = {
+  applicationId: string;
+  status: string;
+};
+
+type UpdateStatusResponse = {
+  id: string;
+  status: string;
+  updatedAt: string;
+};
+
+type UpdateStatusOptions = UseMutationOptions<
+  AxiosResponse<UpdateStatusResponse>,
+  Error,
+  UpdateStatusVariables
+>;
+
+export const useUpdateApplicationStatusMutation = (
+  options: UpdateStatusOptions = {}
+) => {
+  const api = useApplicationDetailApi();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ applicationId, status }: UpdateStatusVariables) => {
+      if (
+        !status ||
+        ![
+          'REJECTED',
+          'INTERVIEW_PENDING',
+          'INTERVIEW_COMPLETED',
+          'HIRED',
+        ].includes(status)
+      ) {
+        throw new Error('유효하지 않은 지원 상태입니다.');
+      }
+
+      const response = await api.updateApplicationStatus(applicationId, {
+        status,
+      });
+
+      return response;
+    },
+    // 단순한 낙관적 업데이트
+    onMutate: async ({ applicationId, status }) => {
+      // 모든 관련 쿼리 취소
+      await queryClient.cancelQueries();
+
+      // 업데이트 함수
+      const updateData = (
+        old: Record<string, unknown> | undefined
+      ): Record<string, unknown> | undefined => {
+        if (!old?.id) return old;
+
+        // ID가 일치하면 상태 업데이트
+        if (String(old.id) === String(applicationId)) {
+          return {
+            ...old,
+            status,
+            updatedAt: new Date().toISOString(),
+          };
+        }
+
+        return old;
+      };
+
+      // 모든 관련 쿼리 즉시 업데이트
+      queryClient.setQueriesData({ queryKey: ['applicationById'] }, updateData);
+
+      queryClient.setQueriesData({ queryKey: ['myApplication'] }, updateData);
+    },
+    onSettled: (data, error, variables, context) => {
+      // 성공/실패 상관없이 서버에서 최신 데이터 가져오기
+      queryClient.invalidateQueries({
+        queryKey: ['applicationById'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['myApplication'],
+      });
+
+      options.onSettled?.(data, error, variables, context);
+    },
+    onSuccess: (data, variables, context) => {
+      options.onSuccess?.(data, variables, context);
+    },
+    onError: (error, variables, context) => {
+      options.onError?.(error, variables, context);
+    },
   });
 };


### PR DESCRIPTION
## 📝 PR 내용 요약

- 지원내역 상태 수정
- 지원서(이력서) 다운로드
- 토스트 적용

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #174 

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---

## 💬 참고 사항

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 지원서 상세 페이지에서 이력서 다운로드 기능이 추가되었습니다.
  * 지원 상태 변경 기능이 도입되어, 지원 상태를 직접 수정할 수 있습니다.

* **버그 수정**
  * 댓글 작성, 알바토크 작성/수정, 비로그인 접근 등 기존 알림창(alert)이 팝업 알림으로 개선되었습니다.
  * 이력서 다운로드 및 상태 변경 시 성공/실패 알림이 팝업으로 안내됩니다.

* **기타**
  * 지원 상태 변경 및 이력서 다운로드 시 UI가 더 직관적으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->