### PR TITLE
[feat] 무한스크롤 적용(알바토크 리스트, 알바토크 댓글 리스트)

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -3,7 +3,7 @@
 const PublicLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div>
-      <main className="lg:mt-160">{children}</main>
+      <main className="mt-52 md:mt-72 lg:mt-84">{children}</main>
     </div>
   );
 };

--- a/src/features/albatalk/components/albatalk-detail/AlbatalkDetailHeader.tsx
+++ b/src/features/albatalk/components/albatalk-detail/AlbatalkDetailHeader.tsx
@@ -16,6 +16,7 @@ const AlbatalkDetailHeader = ({ data }: AlbatalkDetailHeaderProps) => {
         className="border-b border-gray-200"
         title={title}
         titleClassName="pb-16 md:text-xl lg:text-2xl"
+        writerId={writer.id}
       />
       <AlbatalkMetaInfo
         isInteractive // 상호작용 가능

--- a/src/features/albatalk/components/albatalk-detail/CommentItem.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentItem.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import PrimaryButton from '@/shared/components/common/button/PrimaryButton';
 import Textarea from '@/shared/components/common/input/Textarea';
 import KebabMenuDropdown from '@/shared/components/common/kebabMenuDropdown';
+import { useSessionUtils } from '@/shared/lib/auth/use-session-utils';
 import { usePopupStore } from '@/shared/store/popupStore';
 
 import { Comment } from '../../schemas/albatalk.schema';
@@ -21,6 +22,9 @@ const CommentItem = ({ comment, onEdit, onDelete }: CommentItemProps) => {
   const [isEditing, setIsEditing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { showPopup } = usePopupStore();
+
+  const { user } = useSessionUtils();
+  const isOwner = comment.writer.id === user?.id;
 
   useEffect(() => {
     if (isEditing && textareaRef.current) {
@@ -68,7 +72,7 @@ const CommentItem = ({ comment, onEdit, onDelete }: CommentItemProps) => {
           createdAt={comment.createdAt}
           writer={comment.writer}
         />
-        <KebabMenuDropdown options={menuOptions} />
+        {isOwner && <KebabMenuDropdown options={menuOptions} />}
       </div>
 
       {isEditing ? (

--- a/src/features/albatalk/components/albatalk-detail/CommentList.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentList.tsx
@@ -38,7 +38,11 @@ const CommentList = ({ comments, albatalkId }: CommentListProps) => {
   if (comments.length === 0) {
     return (
       <div className="my-100 flex flex-col gap-32 self-center text-center">
-        <EmptyCard type="albaTalkComment" />
+        <EmptyCard
+          description="댓글을 등록하고 의견을 공유해보세요"
+          title="등록된 댓글이 없어요."
+          type="albaTalkComment"
+        />
       </div>
     );
   }

--- a/src/features/albatalk/components/albatalk-form/AddtalkClient.tsx
+++ b/src/features/albatalk/components/albatalk-form/AddtalkClient.tsx
@@ -68,7 +68,7 @@ const AddtalkClient = ({ albatalkId }: AddtalkClientProps) => {
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
 
   useEffect(() => {
-    if (isEditMode && initialData && user?.id) {
+    if (isEditMode && initialData && user) {
       const isOwner = initialData.writer.id === user.id;
       if (!isOwner) {
         setHasAccessDenied(true);
@@ -77,7 +77,7 @@ const AddtalkClient = ({ albatalkId }: AddtalkClientProps) => {
         return;
       }
     }
-  }, [isEditMode, initialData, user?.id, router, showPopup]);
+  }, [isEditMode, initialData, user, router, showPopup]);
 
   // 초기 데이터 설정
   useEffect(() => {

--- a/src/features/albatalk/components/albatalk-form/AddtalkClient.tsx
+++ b/src/features/albatalk/components/albatalk-form/AddtalkClient.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 
 import { useImageMutation } from '@/features/addform/queries/mutations';
 import LoadingSpinner from '@/shared/components/ui/LoadingSpinner';
+import { useSessionUtils } from '@/shared/lib/auth/use-session-utils';
 import { usePopupStore } from '@/shared/store/popupStore';
 
 import {
@@ -29,9 +30,11 @@ const AddtalkClient = ({ albatalkId }: AddtalkClientProps) => {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement>(null);
   const { showPopup } = usePopupStore();
+  const { user } = useSessionUtils();
 
   const isEditMode = !!albatalkId;
   const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
+  const [hasAccessDenied, setHasAccessDenied] = useState(false);
 
   // 이미지 파일 변경 핸들러
   const handleImageFileChange = (file: File | null) => {
@@ -63,6 +66,18 @@ const AddtalkClient = ({ albatalkId }: AddtalkClientProps) => {
   const imageMutation = useImageMutation();
 
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  useEffect(() => {
+    if (isEditMode && initialData && user?.id) {
+      const isOwner = initialData.writer.id === user.id;
+      if (!isOwner) {
+        setHasAccessDenied(true);
+        showPopup('접근 권한이 없습니다.', 'error');
+        router.replace('/albatalk');
+        return;
+      }
+    }
+  }, [isEditMode, initialData, user?.id, router, showPopup]);
 
   // 초기 데이터 설정
   useEffect(() => {
@@ -123,7 +138,7 @@ const AddtalkClient = ({ albatalkId }: AddtalkClientProps) => {
   };
 
   // 로딩상태
-  if (isEditMode && isLoading) {
+  if (isEditMode && (isLoading || hasAccessDenied)) {
     return <LoadingSpinner size="lg" />;
   }
 

--- a/src/features/albatalk/components/albatalk-item/AlbatalkCardHeader.tsx
+++ b/src/features/albatalk/components/albatalk-item/AlbatalkCardHeader.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import KebabMenuDropdown from '@/shared/components/common/kebabMenuDropdown';
 import { cn } from '@/shared/lib/cn';
-import { usePopupStore } from '@/shared/store/popupStore';
 
 import { useDeleteAlbatalk } from '../../hooks/useAlbatalk';
 
@@ -21,21 +21,24 @@ const AlbatalkCardHeader = ({
   className,
   titleClassName,
 }: AlbatalkHeaderProps) => {
-
   const router = useRouter();
   const deleteMutation = useDeleteAlbatalk();
+  const queryClient = useQueryClient();
 
   const handleActionClick = async (option: string) => {
     if (option === 'edit') {
       // 수정 페이지로 이동
       router.push(`/addtalk?albatalkId=${albatalkId}`);
-      
     } else if (option === 'delete') {
       const isConfirmed = window.confirm('정말 이 게시글을 삭제하시겠습니까?');
 
       if (isConfirmed) {
         try {
           await deleteMutation.mutateAsync(albatalkId);
+          // 알바톡 관련 모든 쿼리 무효화
+          queryClient.invalidateQueries({
+            queryKey: ['albatalks'],
+          });
           alert('게시글이 성공적으로 삭제되었습니다.');
 
           router.push('/albatalk');
@@ -50,7 +53,7 @@ const AlbatalkCardHeader = ({
   const menuOptions = [
     { label: '수정하기', onClick: () => handleActionClick('edit') },
     {
-      label: deleteMutation.isPending ? '삭제 중...' : '삭제하기',
+      label: '삭제하기',
       onClick: () => handleActionClick('delete'),
       disabled: deleteMutation.isPending,
     },

--- a/src/features/albatalk/components/albatalk-item/AlbatalkCardHeader.tsx
+++ b/src/features/albatalk/components/albatalk-item/AlbatalkCardHeader.tsx
@@ -4,12 +4,14 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import KebabMenuDropdown from '@/shared/components/common/kebabMenuDropdown';
+import { useSessionUtils } from '@/shared/lib/auth/use-session-utils';
 import { cn } from '@/shared/lib/cn';
 
 import { useDeleteAlbatalk } from '../../hooks/useAlbatalk';
 
 interface AlbatalkHeaderProps {
   title: string;
+  writerId: number;
   albatalkId: number;
   className?: string;
   titleClassName?: string;
@@ -19,11 +21,15 @@ const AlbatalkCardHeader = ({
   title,
   albatalkId,
   className,
+  writerId,
   titleClassName,
 }: AlbatalkHeaderProps) => {
   const router = useRouter();
   const deleteMutation = useDeleteAlbatalk();
   const queryClient = useQueryClient();
+
+  const { user } = useSessionUtils();
+  const isOwner = writerId === user?.id;
 
   const handleActionClick = async (option: string) => {
     if (option === 'edit') {
@@ -69,7 +75,7 @@ const AlbatalkCardHeader = ({
       >
         {title}
       </h2>
-      <KebabMenuDropdown options={menuOptions} />
+      {isOwner && <KebabMenuDropdown options={menuOptions} />}
     </div>
   );
 };

--- a/src/features/albatalk/components/albatalk-item/AlbatalkCardHeader.tsx
+++ b/src/features/albatalk/components/albatalk-item/AlbatalkCardHeader.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import KebabMenuDropdown from '@/shared/components/common/kebabMenuDropdown';
@@ -26,7 +25,6 @@ const AlbatalkCardHeader = ({
 }: AlbatalkHeaderProps) => {
   const router = useRouter();
   const deleteMutation = useDeleteAlbatalk();
-  const queryClient = useQueryClient();
 
   const { user } = useSessionUtils();
   const isOwner = writerId === user?.id;
@@ -41,12 +39,6 @@ const AlbatalkCardHeader = ({
       if (isConfirmed) {
         try {
           await deleteMutation.mutateAsync(albatalkId);
-          // 알바톡 관련 모든 쿼리 무효화
-          queryClient.invalidateQueries({
-            queryKey: ['albatalks'],
-          });
-          alert('게시글이 성공적으로 삭제되었습니다.');
-
           router.push('/albatalk');
         } catch (error) {
           console.error('게시글 삭제 실패:', error);

--- a/src/features/albatalk/components/albatalk-item/AlbatalkMetaInfo.tsx
+++ b/src/features/albatalk/components/albatalk-item/AlbatalkMetaInfo.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 import { Writer } from '@/features/albatalk/schemas/albatalk.schema';
 import { cn } from '@/shared/lib/cn';
+import { usePopupStore } from '@/shared/store/popupStore';
 
 import {
   useAddAlbatalkLike,
@@ -36,6 +37,7 @@ const AlbatalkMetaInfo = ({
   const [isLiked, setIsLiked] = useState(initialIsLiked);
   const [likeCount, setLikeCount] = useState(initialLikeCount);
   const [isToggling, setIsToggling] = useState(false);
+  const { showPopup } = usePopupStore();
 
   const likeIconSrc = isLiked ? '/icons/like-active.svg' : '/icons/like.svg';
 
@@ -64,13 +66,21 @@ const AlbatalkMetaInfo = ({
     try {
       if (isLiked) {
         await removeLikeMutation.mutateAsync(albatalkId); // DELETE
+        showPopup('좋아요를 취소했습니다.', 'error');
       } else {
         await addLikeMutation.mutateAsync(albatalkId); // POST
+        showPopup('좋아요를 눌렀습니다.', 'success');
       }
     } catch (error) {
       setIsLiked(previousLiked);
       setLikeCount(previousCount);
       console.error('좋아요 토글 실패 : ', error);
+
+      if (isLiked) {
+        showPopup('좋아요 취소에 실패했습니다.', 'error');
+      } else {
+        showPopup('좋아요를 실패했습니다.', 'error');
+      }
     } finally {
       setIsToggling(false); // 토글 완료
     }

--- a/src/features/albatalk/components/albatalk-item/AlbatalkMetaInfo.tsx
+++ b/src/features/albatalk/components/albatalk-item/AlbatalkMetaInfo.tsx
@@ -66,7 +66,7 @@ const AlbatalkMetaInfo = ({
     try {
       if (isLiked) {
         await removeLikeMutation.mutateAsync(albatalkId); // DELETE
-        showPopup('좋아요를 취소했습니다.', 'error');
+        showPopup('좋아요를 취소했습니다.', 'success');
       } else {
         await addLikeMutation.mutateAsync(albatalkId); // POST
         showPopup('좋아요를 눌렀습니다.', 'success');

--- a/src/features/albatalk/components/albatalk-item/index.tsx
+++ b/src/features/albatalk/components/albatalk-item/index.tsx
@@ -35,7 +35,11 @@ const AlbatalkItem = ({ albatalk }: AlbatalkItemProps) => {
       onClick={handleClick}
     >
       <div className="min-w-0 flex-1">
-        <AlbatalkCardHeader albatalkId={albatalk.id} title={albatalk.title} />
+        <AlbatalkCardHeader
+          albatalkId={albatalk.id}
+          title={albatalk.title}
+          writerId={albatalk.writer.id}
+        />
         <p className="line-clamp-2 w-220 text-gray-500 dark:text-gray-300">
           {albatalk.content}
         </p>

--- a/src/features/albatalk/hooks/useAlbatalk.ts
+++ b/src/features/albatalk/hooks/useAlbatalk.ts
@@ -76,15 +76,16 @@ export const useAlbatalkDetail = (
  * 게시글 작성 훅
  */
 export const useCreateAlbatalk = () => {
-  const QueryClient = useQueryClient();
+  const queryClient = useQueryClient();
   const authAxios = axiosInstance;
 
   return useMutation({
     mutationFn: (params: CreateAlbatalkParams) =>
       createAlbatalk(params, authAxios),
     onSuccess: () => {
-      QueryClient.invalidateQueries({
-        queryKey: albatalkKeys.lists(),
+      queryClient.invalidateQueries({
+        queryKey: ['albatalks'],
+        exact: false,
       });
     },
     onError: error => {
@@ -112,7 +113,8 @@ export const useUpdateAlbatalk = () => {
       });
 
       queryClient.invalidateQueries({
-        queryKey: albatalkKeys.lists(),
+        queryKey: ['albatalks'],
+        exact: false,
       });
     },
     onError: error => {
@@ -135,7 +137,8 @@ export const useDeleteAlbatalk = () => {
         queryKey: albatalkKeys.detail(postId),
       });
       queryClient.invalidateQueries({
-        queryKey: albatalkKeys.lists(),
+        queryKey: ['albatalks'],
+        exact: false,
       });
       queryClient.removeQueries({
         queryKey: albatalkKeys.comments(postId),
@@ -162,8 +165,9 @@ export const useAddAlbatalkLike = () => {
         queryKey: albatalkKeys.detail(postId),
       });
       // 게시글 목록 쿼리 무효화
-      queryClient.invalidateQueries({
-        queryKey: albatalkKeys.lists(),
+      queryClient.refetchQueries({
+        queryKey: ['albatalks'],
+        exact: false,
       });
     },
     onError: error => {
@@ -185,8 +189,9 @@ export const useRemoveAlbatalkLike = () => {
       queryClient.invalidateQueries({
         queryKey: albatalkKeys.detail(postId),
       });
-      queryClient.invalidateQueries({
-        queryKey: albatalkKeys.lists(),
+      queryClient.refetchQueries({
+        queryKey: ['albatalks'],
+        exact: false,
       });
     },
     onError: error => {

--- a/src/features/albatalk/hooks/useAlbatalk.ts
+++ b/src/features/albatalk/hooks/useAlbatalk.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 
+import { useInfiniteScroll } from '@/shared/hooks/useInfiniteScroll';
 import { axiosInstance } from '@/shared/lib/axios';
 
 import {
@@ -16,7 +17,7 @@ import {
   updateAlbatalk,
   updateComment,
 } from '../api/albatalkApi';
-import type {
+import {
   CreateAlbatalkParams,
   GetAlbatalksParams,
   GetCommentsParams,
@@ -234,6 +235,11 @@ export const useCreateAlbatalkComment = () => {
         queryKey: albatalkKeys.comments(postId),
       });
 
+      // 무한 스크롤 댓글 쿼리도 무효화
+      queryClient.invalidateQueries({
+        queryKey: ['albatalk', 'comments', postId, 'infinite'],
+      });
+
       // 게시글 상세 정보도 무효화 (댓글 수 업데이트를 위해)
       queryClient.invalidateQueries({
         queryKey: albatalkKeys.detail(postId),
@@ -242,6 +248,26 @@ export const useCreateAlbatalkComment = () => {
     onError: error => {
       console.error('댓글 작성 실패:', error);
     },
+  });
+};
+
+/**
+ * 댓글 무한 스크롤 조회 훅
+ */
+export const useAlbatalkCommentsInfinite = (postId: number) => {
+  const authAxios = axiosInstance;
+  const { data: session, status } = useSession();
+
+  const isSessionLoading = status === 'loading';
+  const hasAccessToken = !!session?.accessToken;
+
+  return useInfiniteScroll({
+    mode: 'page',
+    queryKey: ['albatalk', 'comments', postId, 'infinite'],
+    fetcher: (params: GetCommentsParams) =>
+      fetchComments(postId, authAxios, params),
+    initialParams: { page: 1, pageSize: 6 },
+    enabled: !isSessionLoading && hasAccessToken,
   });
 };
 
@@ -266,6 +292,11 @@ export const useUpdateAlbatalkComment = () => {
       // 해당 게시글의 댓글 목록 무효화
       queryClient.invalidateQueries({
         queryKey: albatalkKeys.comments(postId),
+      });
+
+      // 무한 스크롤 댓글 쿼리도 무효화
+      queryClient.invalidateQueries({
+        queryKey: ['albatalk', 'comments', postId, 'infinite'],
       });
     },
     onError: error => {
@@ -293,6 +324,11 @@ export const useDeleteAlbatalkComment = () => {
       // 해당 게시글의 댓글 목록 무효화
       queryClient.invalidateQueries({
         queryKey: albatalkKeys.comments(postId),
+      });
+
+      // 무한 스크롤 댓글 쿼리도 무효화
+      queryClient.invalidateQueries({
+        queryKey: ['albatalk', 'comments', postId, 'infinite'],
       });
 
       // 게시글 상세 정보도 무효화 (댓글 수 업데이트를 위해)

--- a/src/features/albatalk/schemas/albatalk.schema.ts
+++ b/src/features/albatalk/schemas/albatalk.schema.ts
@@ -34,7 +34,7 @@ export const AlbatalkDetailResponseSchema = AlbatalkSchema.extend({
 // GetAlbatalksParams 스키마
 export const GetAlbatalksParamsSchema = z.object({
   limit: z.number(),
-  cursor: z.number().optional(),
+  cursor: z.number().optional().nullable(),
   orderBy: z.enum(['mostRecent', 'mostCommented', 'mostLiked']).optional(),
   keyword: z.string().optional(),
 });


### PR DESCRIPTION
## 📝 PR 내용 요약

- `useInfiniteScroll.ts`를 활용하여 무한 스크롤 적용
- 알바토크 리스트(커서 기반)
- 알바토크 댓글 리스트(페이지 기반)
- 알바토크 게시글 작성자 확인 후 수정 되도록 개선
- 알바 목록, 알바 토크 margin-top 스타일 수정

---

## 🧩 관련 이슈

- Close #179 

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---

## 💬 참고 사항

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 알바톡 댓글 및 게시글 목록에 무한 스크롤 기능이 도입되었습니다.
  * 댓글, 게시글의 소유자만 수정/삭제 메뉴가 노출됩니다.
  * 좋아요 토글 시 성공 및 실패 여부를 알리는 팝업 알림이 추가되었습니다.

* **버그 수정**
  * 댓글이 없을 때 더 친절한 안내 메시지가 표시됩니다.
  * 게시글 수정 시 작성자가 아닌 경우 접근이 제한되고 안내 메시지와 함께 메인 페이지로 이동합니다.

* **스타일**
  * 다양한 화면 크기에 맞춰 메인 영역의 상단 여백이 조정되었습니다.

* **리팩터**
  * 댓글 및 게시글 목록 컴포넌트가 무한 스크롤 패턴으로 개선되었습니다.

* **기타**
  * 일부 스키마에서 cursor 값에 null 허용 등 타입이 명확하게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->