### PR TITLE
[feat] 지원하기 페이지 임시 저장

### DIFF
--- a/src/app/(worker)/layout.tsx
+++ b/src/app/(worker)/layout.tsx
@@ -1,4 +1,0 @@
-const WorkLayout = ({ children }: { children: React.ReactNode }) => {
-  return <main className="mt-52 md:mt-72 lg:mt-84">{children}</main>;
-};
-export default WorkLayout;

--- a/src/features/addform/components/AddformClient.tsx
+++ b/src/features/addform/components/AddformClient.tsx
@@ -163,10 +163,10 @@ const AddformClient = ({ formId }: { formId?: string }) => {
       localStorage.removeItem('addform-draft');
       if (formId) {
         editformMutate({ formId: Number(formId), form: getValues() });
-        showPopup('알바폼 수정이 완료되었습니다.', 'error');
+        showPopup('알바폼 수정이 완료되었습니다.', 'success');
       } else {
         addformMutate(getValues());
-        showPopup('알바폼 생성이 완료되었습니다.', 'error');
+        showPopup('알바폼 생성이 완료되었습니다.', 'success');
       }
     } catch (error) {
       console.error('제출 중 오류 발생:', error);

--- a/src/features/addform/components/AddformClient.tsx
+++ b/src/features/addform/components/AddformClient.tsx
@@ -163,11 +163,14 @@ const AddformClient = ({ formId }: { formId?: string }) => {
       localStorage.removeItem('addform-draft');
       if (formId) {
         editformMutate({ formId: Number(formId), form: getValues() });
+        showPopup('알바폼 수정이 완료되었습니다.', 'error');
       } else {
         addformMutate(getValues());
+        showPopup('알바폼 생성이 완료되었습니다.', 'error');
       }
     } catch (error) {
       console.error('제출 중 오류 발생:', error);
+      showPopup('알바폼 생성 중 오류가 발생했습니다.', 'error');
     }
   };
 
@@ -197,6 +200,7 @@ const AddformClient = ({ formId }: { formId?: string }) => {
       showPopup('알바폼이 임시 저장되었습니다.', 'success');
     } catch (error) {
       console.error('임시 저장 중 오류 발생:', error);
+      showPopup('임시 저장 중 오류가 발생했습니다.', 'error');
     }
   };
 

--- a/src/features/apply/api/index.ts
+++ b/src/features/apply/api/index.ts
@@ -25,6 +25,6 @@ export const postResume = (
 ): Promise<AxiosResponse<UploadResumeResponse>> => {
   const formData = new FormData();
   const newFileName = generateUniqueFileName(file);
-  formData.append('image', file, newFileName);
+  formData.append('file', file, newFileName);
   return axiosInstance.post(`/resume/upload`, formData);
 };

--- a/src/features/apply/components/ApplyForm.tsx
+++ b/src/features/apply/components/ApplyForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import ApplyFormList from '@/features/apply/components/ApplyFormList';
@@ -11,6 +11,7 @@ import {
   useResumeMutation,
 } from '@/features/apply/queries/mutations';
 import {
+  CreateApplicationRequest,
   createApplicationRequestSchema,
   uploadResumeResponseSchema,
 } from '@/features/apply/schema/apply.schema';
@@ -19,14 +20,41 @@ import { usePopupStore } from '@/shared/store/popupStore';
 
 const ApplyForm = ({ formId }: { formId: string }) => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
 
   const { showPopup } = usePopupStore();
 
   const methods = useForm({
     resolver: zodResolver(createApplicationRequestSchema),
     mode: 'onChange',
-    defaultValues: { resumeId: 0, resumeName: '' },
+    defaultValues: {
+      name: '',
+      phoneNumber: '',
+      experienceMonths: undefined,
+      resumeId: 0,
+      resumeName: '',
+      introduction: '',
+      password: '',
+    },
   });
+
+  //로컬 스토리지에서 임시저장 데이터 불러오기
+  useEffect(() => {
+    const draft = localStorage.getItem('apply-draft');
+    if (draft) {
+      const parsed = JSON.parse(draft);
+      const { realResumeName, ...formValues } = parsed;
+      Object.entries(formValues).forEach(([key, value]) => {
+        methods.setValue(
+          key as keyof CreateApplicationRequest,
+          value as CreateApplicationRequest[keyof CreateApplicationRequest],
+          { shouldDirty: true, shouldValidate: true }
+        );
+      });
+      setUploadedFileName(realResumeName);
+      showPopup('임시 저장한 데이터를 가져왔습니다', 'success');
+    }
+  }, [methods, showPopup]);
 
   const { mutateAsync: resumeMutate, isPending: isResumePending } =
     useResumeMutation();
@@ -35,11 +63,33 @@ const ApplyForm = ({ formId }: { formId: string }) => {
   const handleFileChange = (file?: File) => {
     if (file) {
       setSelectedFile(file);
+    } else {
+      setUploadedFileName(null);
+    }
+  };
+
+  const handleSave = async () => {
+    let resume;
+    try {
+      if (selectedFile) {
+        resume = await resumeMutate(selectedFile);
+      }
+      const values = methods.getValues();
+      const draft = {
+        ...values,
+        ...resume?.data,
+        realResumeName: selectedFile?.name,
+      };
+      localStorage.setItem('apply-draft', JSON.stringify(draft));
+      showPopup('알바폼이 임시 저장되었습니다.', 'success');
+    } catch (error) {
+      console.error('임시 저장 중 오류 발생:', error);
+      showPopup('임시 저장 중 오류가 발생했습니다.', 'error');
     }
   };
 
   const handleSubmit = async () => {
-    if (selectedFile)
+    if (selectedFile) {
       try {
         const resume = await resumeMutate(selectedFile);
         const parseResponse = uploadResumeResponseSchema.safeParse(resume.data);
@@ -52,18 +102,28 @@ const ApplyForm = ({ formId }: { formId: string }) => {
         }
         methods.setValue('resumeId', resume.data.resumeId);
         methods.setValue('resumeName', resume.data.resumeName);
-        applyMutate({ formId: Number(formId), form: methods.getValues() });
-        showPopup('지원이 완료되었습니다.', 'success');
       } catch (error) {
-        console.error('제출 중 오류 발생:', error);
-        showPopup('지원 중 오류가 발생했습니다.', 'error');
+        console.error('파일 업로드 중 오류 발생:', error);
+        showPopup('파일 업로드 중 오류가 발생했습니다.', 'error');
       }
+    }
+    try {
+      applyMutate({ formId: Number(formId), form: methods.getValues() });
+      localStorage.removeItem('apply-draft');
+      showPopup('지원이 완료되었습니다.', 'success');
+    } catch (error) {
+      console.error('제출 중 오류 발생:', error);
+      showPopup('지원 중 오류가 발생했습니다.', 'error');
+    }
   };
 
   return (
     <FormProvider {...methods}>
       <form>
-        <ApplyFormList onFileChange={handleFileChange} />
+        <ApplyFormList
+          uploadedFileName={uploadedFileName}
+          onFileChange={handleFileChange}
+        />
         <div className="flex flex-col gap-10 py-10 lg:mt-48 lg:flex-row lg:gap-8 lg:py-0">
           <PrimaryButton
             className={APPLY_FORM_STYLE.button}
@@ -71,12 +131,13 @@ const ApplyForm = ({ formId }: { formId: string }) => {
             label="임시 저장"
             type="button"
             variant="outline"
+            onClick={handleSave}
           />
           <PrimaryButton
             className={APPLY_FORM_STYLE.button}
             disabled={
               !methods.formState.isValid ||
-              !selectedFile ||
+              (!selectedFile && !uploadedFileName) ||
               isResumePending ||
               isApplyPending
             }

--- a/src/features/apply/components/ApplyForm.tsx
+++ b/src/features/apply/components/ApplyForm.tsx
@@ -80,6 +80,10 @@ const ApplyForm = ({ formId }: { formId: string }) => {
         ...resume?.data,
         realResumeName: selectedFile?.name,
       };
+      if (resume) {
+        methods.setValue('resumeId', resume.data.resumeId);
+        methods.setValue('resumeName', resume.data.resumeName);
+      }
       localStorage.setItem('apply-draft', JSON.stringify(draft));
       showPopup('알바폼이 임시 저장되었습니다.', 'success');
     } catch (error) {

--- a/src/features/apply/components/ApplyForm.tsx
+++ b/src/features/apply/components/ApplyForm.tsx
@@ -15,9 +15,12 @@ import {
   uploadResumeResponseSchema,
 } from '@/features/apply/schema/apply.schema';
 import PrimaryButton from '@/shared/components/common/button/PrimaryButton';
+import { usePopupStore } from '@/shared/store/popupStore';
 
 const ApplyForm = ({ formId }: { formId: string }) => {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  const { showPopup } = usePopupStore();
 
   const methods = useForm({
     resolver: zodResolver(createApplicationRequestSchema),
@@ -50,8 +53,10 @@ const ApplyForm = ({ formId }: { formId: string }) => {
         methods.setValue('resumeId', resume.data.resumeId);
         methods.setValue('resumeName', resume.data.resumeName);
         applyMutate({ formId: Number(formId), form: methods.getValues() });
+        showPopup('지원이 완료되었습니다.', 'success');
       } catch (error) {
         console.error('제출 중 오류 발생:', error);
+        showPopup('지원 중 오류가 발생했습니다.', 'error');
       }
   };
 

--- a/src/features/apply/components/ApplyFormList.tsx
+++ b/src/features/apply/components/ApplyFormList.tsx
@@ -49,9 +49,14 @@ const ApplyFormList = ({
         <Input
           {...register('name')}
           id="name"
+          isInvalid={!!errors.name}
           placeholder="이름을 입력해주세요."
           type="text"
           variant="solid"
+        />
+        <ErrorMessage
+          isVisible={!!errors.name}
+          message={errors.name?.message}
         />
       </li>
       <li className={itemStyle}>
@@ -61,9 +66,14 @@ const ApplyFormList = ({
         <Input
           {...register('phoneNumber')}
           id="phone"
+          isInvalid={!!errors.phoneNumber}
           placeholder="숫자만 입력해주세요."
           type="tel"
           variant="solid"
+        />
+        <ErrorMessage
+          isVisible={!!errors.phoneNumber}
+          message={errors.phoneNumber?.message}
         />
       </li>
       <li className={itemStyle}>
@@ -85,7 +95,9 @@ const ApplyFormList = ({
         />
       </li>
       <li className={itemStyle}>
-        <Label htmlFor="resume">이력서</Label>
+        <Label isRequired htmlFor="resume">
+          이력서
+        </Label>
         <div className="relative">
           <IconInput
             readOnly
@@ -116,13 +128,20 @@ const ApplyFormList = ({
         </div>
       </li>
       <li className={itemStyle}>
-        <Label htmlFor="introduction">자기소개</Label>
+        <Label isRequired htmlFor="introduction">
+          자기소개
+        </Label>
         <Textarea
           {...register('introduction')}
           id="introduction"
+          isInvalid={!!errors.introduction}
           maxLength={200}
           placeholder="최대 200자까지 입력 가능합니다."
           variant="solid"
+        />
+        <ErrorMessage
+          isVisible={!!errors.introduction}
+          message={errors.introduction?.message}
         />
       </li>
       <li className={itemStyle}>
@@ -132,6 +151,7 @@ const ApplyFormList = ({
         <Input
           {...register('password')}
           id="password"
+          isInvalid={!!errors.password}
           placeholder="비밀번호를 입력해주세요."
           type="password"
           variant="solid"

--- a/src/features/apply/components/ApplyFormList.tsx
+++ b/src/features/apply/components/ApplyFormList.tsx
@@ -15,11 +15,13 @@ import { cn } from '@/shared/lib/cn';
 
 const ApplyFormList = ({
   onFileChange,
+  uploadedFileName,
 }: {
   onFileChange: (file?: File) => void;
+  uploadedFileName?: string | null;
 }) => {
   const [selectedFileName, setSelectedFileName] = useState<string>('');
-  const isFileSelected = selectedFileName !== '';
+  const isFileSelected = selectedFileName !== '' || !!uploadedFileName;
   const itemStyle = APPLY_FORM_STYLE.listItem;
 
   const {
@@ -81,8 +83,12 @@ const ApplyFormList = ({
           경력(개월 수)
         </Label>
         <Input
-          {...register('experienceMonths', { valueAsNumber: true })}
+          {...register('experienceMonths', {
+            setValueAs: value =>
+              value === '' || value === undefined ? undefined : Number(value),
+          })}
           id="career"
+          isInvalid={!!errors.experienceMonths}
           min={0}
           placeholder="숫자만 입력해주세요."
           step={1}
@@ -108,7 +114,7 @@ const ApplyFormList = ({
             placeholder="파일 업로드하기"
             position="right"
             src={isFileSelected ? '/icons/x-circle.svg' : '/icons/upload.svg'}
-            value={selectedFileName || ''}
+            value={selectedFileName || uploadedFileName || ''}
           />
           <InputFile
             accept=".pdf,.docx,.doc"

--- a/src/features/apply/queries/mutations.ts
+++ b/src/features/apply/queries/mutations.ts
@@ -36,7 +36,7 @@ export const useApplyMutation = () => {
       // 회원은 지원 상세 페이지로, 비회원은 알바폼 상세 페이지로
       if (parseResponse.data.applicantId) {
         queryClient.setQueryData(
-          ['myApplication', variables.formId],
+          ['myApplication', String(variables.formId)],
           parseResponse.data
         );
         router.push(`/myapply/${variables.formId}`);

--- a/src/features/apply/schema/apply.schema.ts
+++ b/src/features/apply/schema/apply.schema.ts
@@ -10,14 +10,19 @@ export const createApplicationRequestSchema = z.object({
     }),
   introduction: z
     .string()
+    .min(1, { error: '자기소개를 입력 해주세요.' })
     .max(200, { error: '최대 200자까지 입력 가능합니다.' }),
   resumeName: z.string(),
   resumeId: z.number(),
   experienceMonths: z
     .number({ error: '숫자만 입력해주세요.' })
     .min(0, { error: '0 이상의 숫자를 입력해주세요.' }),
-  phoneNumber: z.string(),
-  name: z.string(),
+  phoneNumber: z
+    .string()
+    .regex(/^\d+$/, { error: '숫자만 입력해주세요.' })
+    .min(10, { error: '휴대폰 번호는 최소 10자리 이상이어야 합니다.' })
+    .max(11, { error: '휴대폰 번호는 최대 11자리까지 입력 가능합니다.' }),
+  name: z.string().min(1, { error: '이름을 입력 해주세요.' }),
 });
 
 export const createApplicationResponseSchema = createApplicationRequestSchema

--- a/src/shared/components/common/input/inputStyles.ts
+++ b/src/shared/components/common/input/inputStyles.ts
@@ -5,7 +5,7 @@ export const inputStyle = {
     transition duration-200
   `,
   invalid:
-    'border border-error caret-error hover:border-error focus:border-error focus:outline-error',
+    'border border-error caret-error dark:caret-error hover:border-error focus:border-0 ',
 };
 
 export const inputVariants = {


### PR DESCRIPTION
## 📝 PR 내용 요약

> 어떤 작업을 했는지 간단히 요약해주세요.

- 지원하기 페이지 임시저장 구현
- 지원하기 페이지, 폼 생성 토스트 추가
- (worker)파일 제거

---

## 🧩 관련 이슈

> 관련된 이슈 번호를 적어주세요. (자동으로 닫으려면 Close #이슈번호)

- Close #172

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---

## 💬 참고 사항

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 지원서 작성 폼에 임시 저장 및 불러오기 기능이 추가되었습니다.
  * 지원서 작성 및 임시 저장, 파일 업로드, 제출 시 성공/실패 팝업 알림이 제공됩니다.

* **버그 수정**
  * 파일 업로드 시 파일 키가 'file'로 수정되어 업로드 오류가 해결되었습니다.

* **개선 사항**
  * 지원서 입력값 유효성 검사가 강화되어, 이름, 자기소개, 휴대폰 번호 입력 시 상세한 오류 메시지가 표시됩니다.
  * 입력 폼에서 유효하지 않은 값 입력 시 시각적 피드백이 개선되었습니다.
  * 지원서 폼에서 파일명 표시 및 필수 입력 항목 표시가 명확해졌습니다.

* **기타**
  * 불필요한 레이아웃 컴포넌트가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->