### PR TITLE
[fix] 댓글 작성 완료 후 데이터 중복 요청 개선

### DIFF
--- a/src/app/(public)/albatalk/[id]/page.tsx
+++ b/src/app/(public)/albatalk/[id]/page.tsx
@@ -1,8 +1,17 @@
+import { redirect } from 'next/navigation';
+
+import { auth } from '@/auth';
 import AlbatalkDetail from '@/features/albatalk/components/albatalk-detail';
 
 const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
   const { id } = await params;
   const albatalkId = Number(id);
+
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect('/signin');
+  }
 
   if (isNaN(albatalkId) || albatalkId <= 0) {
     throw new Error('유효하지 않은 게시글 ID입니다.');

--- a/src/features/albatalk/components/albatalk-detail/CommentSection.tsx
+++ b/src/features/albatalk/components/albatalk-detail/CommentSection.tsx
@@ -27,7 +27,13 @@ const CommentSection = ({ albatalkId }: CommentSectionProps) => {
   const totalCount =
     firstPage && 'totalItemCount' in firstPage ? firstPage.totalItemCount : 0;
 
-  if (isLoading) return <LoadingSpinner size="lg" />;
+  if (isLoading) {
+    return (
+      <div className="flex justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
 
   if (isError)
     return <div className="text-red-500">댓글을 불러오는데 실패했습니다.</div>;

--- a/src/features/albatalk/components/albatalk-detail/index.tsx
+++ b/src/features/albatalk/components/albatalk-detail/index.tsx
@@ -1,9 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
-import { useEffect } from 'react';
-
 import EmptyCard from '@/shared/components/common/EmptyCard';
 import LoadingSpinner from '@/shared/components/ui/LoadingSpinner';
 
@@ -17,8 +13,6 @@ interface AlbatalkDetailProps {
 }
 
 const AlbatalkDetail = ({ albatalkId }: AlbatalkDetailProps) => {
-  const router = useRouter();
-  const { status } = useSession();
   const {
     data: albatalk,
     isPending,
@@ -26,23 +20,12 @@ const AlbatalkDetail = ({ albatalkId }: AlbatalkDetailProps) => {
     error,
   } = useAlbatalkDetail(albatalkId);
 
-  // 로그인 상태 체크 및 리다이렉트
-  useEffect(() => {
-    if (status === 'unauthenticated') {
-      router.push('/signin');
-    }
-  }, [status, router]);
-
-  if (status === 'loading') {
-    return <LoadingSpinner size="lg" />;
-  }
-
   if (isPending) {
-    return <LoadingSpinner size="lg" />;
-  }
-
-  if (status === 'unauthenticated') {
-    return <LoadingSpinner size="lg" />;
+    return (
+      <div className="flex justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
   }
 
   if (isError) {

--- a/src/features/albatalk/hooks/useAlbatalk.ts
+++ b/src/features/albatalk/hooks/useAlbatalk.ts
@@ -58,15 +58,11 @@ export const useAlbatalkDetail = (
   options?: { enabled?: boolean }
 ) => {
   const authAxios = axiosInstance;
-  const { data: session, status } = useSession(); // 세션과 상태 가져오기
-
-  const isSessionLoading = status === 'loading';
-  const hasAccessToken = !!session?.accessToken;
 
   return useQuery({
     queryKey: albatalkKeys.detail(postId),
     queryFn: () => fetchAlbatalkDetail(postId, authAxios),
-    enabled: !isSessionLoading && hasAccessToken && options?.enabled !== false,
+    enabled: options?.enabled !== false,
     staleTime: 1000 * 60 * 5, // 5분
     gcTime: 1000 * 60 * 10, // 10분
   });
@@ -235,11 +231,6 @@ export const useCreateAlbatalkComment = () => {
     mutationFn: ({ postId, content }: { postId: number; content: string }) =>
       createComment(postId, content, authAxios),
     onSuccess: (_, { postId }) => {
-      // 해당 게시글의 댓글 목록 무효화
-      queryClient.invalidateQueries({
-        queryKey: albatalkKeys.comments(postId),
-      });
-
       // 무한 스크롤 댓글 쿼리도 무효화
       queryClient.invalidateQueries({
         queryKey: ['albatalk', 'comments', postId, 'infinite'],

--- a/src/features/application/components/application-detail/index.tsx
+++ b/src/features/application/components/application-detail/index.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 
 import AlbaDescription from '@/shared/components/alba/AlbaDescription';
 import AlbaDetail from '@/shared/components/alba/AlbaDetail';
+import LoadingSpinner from '@/shared/components/ui/LoadingSpinner';
 import { useSessionUtils } from '@/shared/lib/auth/use-session-utils';
 import useApplicationStore from '@/shared/store/useApplicationStore';
 import { createSlidesFromUrls } from '@/shared/utils/carousel';
@@ -97,7 +98,7 @@ const ApplicationDetail = ({
   if (isLoading) {
     return (
       <div className="flex min-h-[400px] flex-col items-center justify-center gap-4">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" />
+        <LoadingSpinner size="lg" />
         <p className="text-gray-600">데이터를 불러오는 중...</p>
       </div>
     );


### PR DESCRIPTION
## 📝 PR 내용 요약

- 알바토크 상세페이지 로딩 스피너 가운데 정렬
- 지원내역 상세페이지 로딩 스피너 변경
- 댓글 작성 후 데이터 두번 불러오는 버그 수정

---

## 🧩 관련 이슈

- Close #190 

---

## 📸 스크린샷 (선택)

> UI 변경이 있을 경우 첨부해주세요.

(이미지 첨부)

---

## 💬 참고 사항

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 댓글 섹션과 지원서 상세 화면에서 로딩 스피너가 중앙에 정렬되어 더 보기 좋게 개선되었습니다.
  * 지원서 상세 화면의 로딩 표시가 일관된 스피너 컴포넌트로 변경되었습니다.

* **리팩터**
  * 알바톡 상세 화면에서 인증 상태 확인 및 리다이렉트 로직이 제거되어, 데이터 로딩 상태에만 집중하도록 단순화되었습니다.
  * 알바톡 상세 조회 및 댓글 관련 훅에서 인증 세션 상태에 따른 쿼리 활성화 및 일부 쿼리 무효화 로직이 정리되었습니다.

* **신규 기능**
  * 알바톡 상세 페이지 접근 시 로그인하지 않은 사용자는 자동으로 로그인 페이지로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->