### PR TITLE
[Refactor] 알바 카드 목록 제목 요소 바깥으로 넘침 해결

### DIFF
--- a/src/shared/components/common/list/AlbaCardItem.tsx
+++ b/src/shared/components/common/list/AlbaCardItem.tsx
@@ -132,27 +132,28 @@ const AlbaCardItem = ({
         {formatDateLong(recruitmentEndDate)}
       </span>
 
-      <div className="mt-12 ml-4 flex items-center gap-4">
-        <div className="mr-8 min-w-0 flex-1">
-          <TitleMarquee title={title} />
+      <div className="mt-12 ml-4 flex items-center">
+        <div className="flex min-w-0 items-center">
+          <div className="mr-4 min-w-0">
+            <TitleMarquee title={title} />
+          </div>
+          {isIcon &&
+            (isScrapped ? (
+              <Image
+                alt="스크랩 완료"
+                height={24}
+                src="/icons/bookmark-mint.svg"
+                width={24}
+              />
+            ) : (
+              <Image
+                alt="스크랩 안됨"
+                height={24}
+                src="/icons/bookmark-gray.svg"
+                width={24}
+              />
+            ))}
         </div>
-        {isIcon &&
-          (isScrapped ? (
-            <Image
-              alt="스크랩 완료"
-              height={20}
-              src="/icons/bookmark-mint.svg"
-              width={20}
-            />
-          ) : (
-            <Image
-              alt="스크랩 안됨"
-              className="mr-3"
-              height={20}
-              src="/icons/bookmark-gray.svg"
-              width={20}
-            />
-          ))}
       </div>
 
       <div className="mt-20 flex h-40 w-full justify-center rounded-lg bg-gray-25 text-xs text-gray-600 lg:h-45 dark:bg-gray-800">

--- a/src/shared/components/common/list/AlbaCardItem.tsx
+++ b/src/shared/components/common/list/AlbaCardItem.tsx
@@ -69,7 +69,7 @@ const AlbaCardItem = ({
   const dDayClass = cn(
     dDay < 0 && 'text-gray-400',
     dDay >= 0 && dDay <= 3 && 'text-error brightness-150 font-semibold',
-    dDay > 3 && 'text-gray-600 hover:text-gray-900'
+    dDay > 3 && 'text-gray-600 hover:text-gray-900 dark:text-gray-100'
   );
 
   // 알바 카드의 통계 정보
@@ -156,12 +156,13 @@ const AlbaCardItem = ({
         </div>
       </div>
 
-      <div className="mt-20 flex h-40 w-full justify-center rounded-lg bg-gray-25 text-xs text-gray-600 lg:h-45 dark:bg-gray-800">
+      <div className="mt-20 flex h-40 w-full justify-center rounded-lg bg-gray-25 text-xs text-gray-900 lg:h-45 dark:bg-gray-800">
         {stats.map((stat, idx) => (
           <span
             key={stat.label}
             className={cn(
-              'relative flex flex-1 items-center justify-center whitespace-nowrap dark:text-gray-100',
+              'relative flex flex-1 items-center justify-center whitespace-nowrap',
+              !stat.isDeadline && 'dark:text-gray-100',
               idx !== stats.length - 1 &&
                 'after:absolute after:top-1/2 after:right-0 after:h-14 after:w-1 after:-translate-y-1/2 after:bg-gray-100',
               stat.isDeadline && dDayClass

--- a/src/shared/components/common/list/AlbaCardItem.tsx
+++ b/src/shared/components/common/list/AlbaCardItem.tsx
@@ -133,7 +133,7 @@ const AlbaCardItem = ({
       </span>
 
       <div className="mt-12 ml-4 flex items-center gap-4">
-        <div className="flex-1">
+        <div className="mr-8 min-w-0 flex-1">
           <TitleMarquee title={title} />
         </div>
         {isIcon &&

--- a/src/shared/components/ui/TitleMarquee.tsx
+++ b/src/shared/components/ui/TitleMarquee.tsx
@@ -35,7 +35,7 @@ const TitleMarquee = ({ title }: TitleMarqueeProps) => {
   return (
     <div
       ref={containerRef}
-      className={`relative max-w-345 overflow-hidden text-2lg font-bold whitespace-nowrap lg:text-xl ${
+      className={`relative w-full overflow-hidden text-2lg font-bold whitespace-nowrap lg:text-xl ${
         pathname?.startsWith('/alba/') ? 'lg:max-w-500' : ''
       }`}
     >


### PR DESCRIPTION
## 📝 PR 내용 요약
- 알바 카드의 제목 부분 고정 너비 변경
- 알바 카드 제목의 부모 태그에 속성 적용
- 스크랩 아이콘 제목 옆에 딱 붙도록 수정
- 다크모드 시에 마감일 강조 색상 미적용 문제 수정
---

## 🧩 관련 이슈
- Close #208 
---

## 📸 스크린샷 (선택)
- 추후 반영
---

## 💬 참고 사항

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 다크 모드에서 D-Day와 통계 텍스트 색상이 개선되었습니다.
  * 카드 제목과 스크랩 아이콘의 레이아웃이 변경되어 더욱 일관된 정렬과 시각적 구성이 제공됩니다.
  * 스크랩 아이콘 크기가 기존보다 커졌습니다.
  * TitleMarquee 컴포넌트의 기본 너비가 전체로 확장되어 더 넓은 영역을 활용합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->